### PR TITLE
dt-bindings: riscv: cpus: Add missing additionalProperties on interrupt-controller node

### DIFF
--- a/Documentation/devicetree/bindings/riscv/cpus.yaml
+++ b/Documentation/devicetree/bindings/riscv/cpus.yaml
@@ -91,6 +91,7 @@ properties:
 
   interrupt-controller:
     type: object
+    additionalProperties: false
     description: Describes the CPU's local interrupt controller
 
     properties:


### PR DESCRIPTION
Pull request for series with
subject: dt-bindings: riscv: cpus: Add missing additionalProperties on interrupt-controller node
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=784819
