### PR TITLE
soc: Convert to platform remove callback returning void

### DIFF
--- a/drivers/soc/microchip/mpfs-sys-controller.c
+++ b/drivers/soc/microchip/mpfs-sys-controller.c
@@ -149,13 +149,11 @@ static int mpfs_sys_controller_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int mpfs_sys_controller_remove(struct platform_device *pdev)
+static void mpfs_sys_controller_remove(struct platform_device *pdev)
 {
 	struct mpfs_sys_controller *sys_controller = platform_get_drvdata(pdev);
 
 	mpfs_sys_controller_put(sys_controller);
-
-	return 0;
 }
 
 static const struct of_device_id mpfs_sys_controller_of_match[] = {
@@ -207,7 +205,7 @@ static struct platform_driver mpfs_sys_controller_driver = {
 		.of_match_table = mpfs_sys_controller_of_match,
 	},
 	.probe = mpfs_sys_controller_probe,
-	.remove = mpfs_sys_controller_remove,
+	.remove_new = mpfs_sys_controller_remove,
 };
 module_platform_driver(mpfs_sys_controller_driver);
 


### PR DESCRIPTION
Pull request for series with
subject: soc: Convert to platform remove callback returning void
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=787204
