### PR TITLE
selftests: Fix wrong TARGET in kselftest top level Makefile

### DIFF
--- a/tools/testing/selftests/Makefile
+++ b/tools/testing/selftests/Makefile
@@ -92,7 +92,7 @@ endif
 TARGETS += tmpfs
 TARGETS += tpm2
 TARGETS += tty
-TARGETS += uevents
+TARGETS += uevent
 TARGETS += user
 TARGETS += user_events
 TARGETS += vDSO


### PR DESCRIPTION
Pull request for series with
subject: selftests: Fix wrong TARGET in kselftest top level Makefile
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=787746
