### PR TITLE
MAINTAINERS: Add Hal as one of the maintainers of SFCTEMP HWMON DRIVER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -19402,6 +19402,7 @@ F:	drivers/net/ethernet/sfc/
 
 SFCTEMP HWMON DRIVER
 M:	Emil Renner Berthing <kernel@esmil.dk>
+M:	Hal Feng <hal.feng@starfivetech.com>
 L:	linux-hwmon@vger.kernel.org
 S:	Maintained
 F:	Documentation/devicetree/bindings/hwmon/starfive,jh71x0-temp.yaml


### PR DESCRIPTION
Pull request for series with
subject: MAINTAINERS: Add Hal as one of the maintainers of SFCTEMP HWMON DRIVER
version: 2
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=788379
