### PR TITLE
dt-bindings: cache: andestech,ax45mp-cache: Fix unit address in example

### DIFF
--- a/Documentation/devicetree/bindings/cache/andestech,ax45mp-cache.yaml
+++ b/Documentation/devicetree/bindings/cache/andestech,ax45mp-cache.yaml
@@ -69,7 +69,7 @@ examples:
   - |
     #include <dt-bindings/interrupt-controller/irq.h>
 
-    cache-controller@2010000 {
+    cache-controller@13400000 {
         compatible = "andestech,ax45mp-cache", "cache";
         reg = <0x13400000 0x100000>;
         interrupts = <508 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
Pull request for series with
subject: dt-bindings: cache: andestech,ax45mp-cache: Fix unit address in example
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=789553
