### PR TITLE
soc: renesas: make ARCH_R9A07G043 (riscv version) depend on NONPORTABLE

### DIFF
--- a/drivers/soc/renesas/Kconfig
+++ b/drivers/soc/renesas/Kconfig
@@ -333,6 +333,7 @@ if RISCV
 
 config ARCH_R9A07G043
 	bool "RISC-V Platform support for RZ/Five"
+	depends on NONPORTABLE
 	select ARCH_RZG2L
 	select AX45MP_L2_CACHE if RISCV_DMA_NONCOHERENT
 	select DMA_GLOBAL_POOL


### PR DESCRIPTION
Pull request for series with
subject: soc: renesas: make ARCH_R9A07G043 (riscv version) depend on NONPORTABLE
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=789975
