### PR TITLE
riscv: dts: sophgo: remove address-cells from intc node

### DIFF
--- a/arch/riscv/boot/dts/sophgo/cv1800b.dtsi
+++ b/arch/riscv/boot/dts/sophgo/cv1800b.dtsi
@@ -34,7 +34,6 @@
 			cpu0_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
-				#address-cells = <0>;
 				#interrupt-cells = <1>;
 			};
 		};


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: sophgo: remove address-cells from intc node
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=795929
