### PR TITLE
riscv: CONFIG_EFI should not depend on CONFIG_RISCV_ISA_C

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -817,7 +817,6 @@ config EFI
 	select EFI_RUNTIME_WRAPPERS
 	select EFI_STUB
 	select LIBFDT
-	select RISCV_ISA_C
 	select UCS2_STRING
 	help
 	  This option provides support for runtime services provided

--- a/arch/riscv/kernel/head.S
+++ b/arch/riscv/kernel/head.S
@@ -28,9 +28,13 @@ SYM_CODE_START(_start)
 	 */
 #ifdef CONFIG_EFI
 	/*
-	 * This instruction decodes to "MZ" ASCII required by UEFI.
+	 * The compressed (C extension) "c.li s4,-13" instruction
+	 * decodes to 0x5a4d/"MZ" (ASCII), which is required by UEFI.
+	 *
+	 * In order to support non-compressed EFI kernels, the
+	 * instruction is written in hex.
 	 */
-	c.li s4,-13
+	.word 0x5a4d5a4d
 	j _start_kernel
 #else
 	/* jump to start kernel */


### PR DESCRIPTION
Pull request for series with
subject: riscv: CONFIG_EFI should not depend on CONFIG_RISCV_ISA_C
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=796142
