### PR TITLE
scripts/gdb: add lx_current support for riscv

### DIFF
--- a/.github/scripts/helpers.sh
+++ b/.github/scripts/helpers.sh
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+
+group_start() {
+    echo "::group::$1"
+}
+
+group_end() {
+    echo "::endgroup::"
+}

--- a/.github/scripts/patch_tester.sh
+++ b/.github/scripts/patch_tester.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+d=$(dirname "${BASH_SOURCE[0]}")
+
+sha1=$1
+patch_num=$2
+patch_tot=$3
+
+worktree=$(mktemp -d)
+git worktree add $worktree ${sha1} &>/dev/null
+cd $worktree
+
+rc=0
+tests=( $(ls ${d}/patches/*.sh) )
+tcnt=1
+for j in "${tests[@]}"; do
+    git reset --hard ${sha1} &>/dev/null
+    msg="Patch ${patch_num}/${patch_tot}: Test ${tcnt}/${#tests[@]}: ${j}"
+    echo "::group::${msg}"
+    testrc=0
+    bash ${j} || testrc=$?
+    echo "::endgroup::"
+    if (( $testrc == 250 )); then
+        rc=1
+        echo "::warning::WARN ${msg}"
+    elif (( $testrc )); then
+        rc=1
+        echo "::error::FAIL ${msg}"
+    else
+        echo "::notice::OK ${msg}"
+    fi
+    tcnt=$(( tcnt + 1 ))
+done
+
+git worktree remove $worktree &>/dev/null || true
+
+exit $rc

--- a/.github/scripts/patches.sh
+++ b/.github/scripts/patches.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+d=$(dirname "${BASH_SOURCE[0]}")
+
+. ${d}/helpers.sh
+
+basesha=$(git log -1 --pretty=%H .github/scripts/helpers.sh)
+patches=( $(git rev-list --reverse ${basesha}..HEAD) )
+patch_tot=${#patches[@]}
+rc=0
+cnt=1
+parallel -j 3 --colsep=, bash ${d}/patch_tester.sh {1} {2} {3} :::: <(
+    for i in "${patches[@]}"; do
+	echo ${i},${cnt},${patch_tot}
+	cnt=$(( cnt + 1 ))
+    done) || rc=1
+
+exit $rc

--- a/.github/scripts/patches/build_rv32_defconfig.sh
+++ b/.github/scripts/patches/build_rv32_defconfig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2022 by Rivos Inc.
+
+tmpdir=build
+tmpfile=$(mktemp)
+rc=0
+
+tuxmake --wrapper ccache --target-arch riscv --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir --toolchain llvm -z none -k rv32_defconfig \
+        CROSS_COMPILE=riscv64-linux- \
+        >$tmpfile 2>/dev/null || rc=1
+
+if [ $rc -ne 0 ]; then
+        grep "\(warning\|error\):" $tmpfile
+fi
+
+rm -rf $tmpdir $tmpfile
+
+exit $rc

--- a/.github/scripts/patches/build_rv64_clang_allmodconfig.sh
+++ b/.github/scripts/patches/build_rv64_clang_allmodconfig.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Netronome Systems, Inc.
+
+# Modified tests/patch/build_defconfig_warn.sh for RISC-V builds
+
+tmpfile_e=$(mktemp)
+tmpfile_o=$(mktemp)
+tmpfile_n=$(mktemp)
+
+tmpdir_b=build_llvm
+tmpdir_o=output
+
+rc=0
+
+echo "Redirect to $tmpfile_o and $tmpfile_n"
+
+HEAD=$(git rev-parse HEAD)
+
+echo "Tree base:"
+git log -1 --pretty='%h ("%s")' HEAD~
+
+echo "Building the whole tree with the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y -K CONFIG_SAMPLES=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_e 2>/dev/null || rc=1
+
+if [ $rc -eq 1 ]; then
+        grep "\(error\):" $tmpfile_e
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+        exit $rc
+fi
+
+current=$(grep -c "\(warning\|error\):" $tmpfile_n)
+
+git checkout -q HEAD~
+
+echo "Building the tree before the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_o 2>/dev/null
+
+incumbent=$(grep -c "\(warning\|error\):" $tmpfile_o)
+
+git checkout -q $HEAD
+
+echo "Building the tree with the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_n 2>/dev/null || rc=1
+
+if [ $rc -eq 1 ]; then
+        grep "\(warning\|error\):" $tmpfile_n
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+        exit $rc
+fi
+
+current=$(grep -c "\(warning\|error\):" $tmpfile_n)
+
+if [ $current -gt $incumbent ]; then
+        echo "New errors added:"
+
+        tmpfile_errors_before=$(mktemp)
+        tmpfile_errors_now=$(mktemp)
+        grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
+        grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
+
+        diff -U 0 $tmpfile_errors_before $tmpfile_errors_now
+
+        rm $tmpfile_errors_before $tmpfile_errors_now
+
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
+
+        grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fo
+        grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fn
+
+        diff -U 0 $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        echo "pre: $incumbent post: $current"
+        rc=1
+fi
+
+rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+
+exit $rc

--- a/.github/scripts/patches/build_rv64_gcc_allmodconfig.sh
+++ b/.github/scripts/patches/build_rv64_gcc_allmodconfig.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Netronome Systems, Inc.
+
+# Modified tests/patch/build_defconfig_warn.sh for RISC-V builds
+
+tmpfile_e=$(mktemp)
+tmpfile_o=$(mktemp)
+tmpfile_n=$(mktemp)
+
+tmpdir_b=build_gcc
+tmpdir_o=output
+
+rc=0
+
+echo "Redirect to $tmpfile_o and $tmpfile_n"
+
+HEAD=$(git rev-parse HEAD)
+
+echo "Tree base:"
+git log -1 --pretty='%h ("%s")' HEAD~
+
+echo "Building the whole tree with the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_e 2>/dev/null || rc=1
+
+if [ $rc -eq 1 ]; then
+        grep "\(error\):" $tmpfile_e
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+        exit $rc
+fi
+
+git checkout -q HEAD~
+
+echo "Building the tree before the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_o 2>/dev/null
+
+incumbent=$(grep -c "\(warning\|error\):" $tmpfile_o)
+
+git checkout -q $HEAD
+
+echo "Building the tree with the patch"
+
+tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_n 2>/dev/null || rc=1
+
+if [ $rc -eq 1 ]; then
+        grep "\(warning\|error\):" $tmpfile_n
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+        exit $rc
+fi
+
+current=$(grep -c "\(warning\|error\):" $tmpfile_n)
+
+if [ $current -gt $incumbent ]; then
+        echo "New errors added:"
+
+        tmpfile_errors_before=$(mktemp)
+        tmpfile_errors_now=$(mktemp)
+        grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
+        grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
+
+        diff -U 0 $tmpfile_errors_before $tmpfile_errors_now
+
+        rm $tmpfile_errors_before $tmpfile_errors_now
+
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
+
+        grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fo
+        grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fn
+
+        diff -U 0 $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        echo "pre: $incumbent post: $current"
+
+        rc=1
+fi
+
+rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+
+exit $rc

--- a/.github/scripts/patches/build_rv64_nommu_k210_defconfig.sh
+++ b/.github/scripts/patches/build_rv64_nommu_k210_defconfig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2022 by Rivos Inc.
+
+tmpdir=$(mktemp -d)
+tmpfile=$(mktemp)
+rc=0
+
+tuxmake --wrapper ccache --target-arch riscv --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir --toolchain gcc -z none -k nommu_k210_defconfig \
+        CROSS_COMPILE=riscv64-linux- \
+        >$tmpfile 2>/dev/null || rc=1
+
+if [ $rc -ne 0 ]; then
+        grep "\(warning\|error\):" $tmpfile
+fi
+
+rm -rf $tmpdir $tmpfile
+
+exit $rc

--- a/.github/scripts/patches/build_rv64_nommu_virt_defconfig.sh
+++ b/.github/scripts/patches/build_rv64_nommu_virt_defconfig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2022 by Rivos Inc.
+
+tmpdir=$(mktemp -d)
+tmpfile=$(mktemp)
+rc=0
+
+tuxmake --wrapper ccache --target-arch riscv --directory . \
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir --toolchain gcc -z none -k nommu_virt_defconfig \
+        CROSS_COMPILE=riscv64-linux- \
+        >$tmpfile 2>/dev/null || rc=1
+
+if [ $rc -ne 0 ]; then
+        grep "\(warning\|error\):" $tmpfile
+fi
+
+rm -rf $tmpdir $tmpfile
+
+exit $rc

--- a/.github/scripts/patches/checkpatch.sh
+++ b/.github/scripts/patches/checkpatch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Netronome Systems, Inc.
+
+IGNORED=\
+COMMIT_LOG_LONG_LINE,\
+MACRO_ARG_REUSE,\
+ALLOC_SIZEOF_STRUCT,\
+NO_AUTHOR_SIGN_OFF,\
+GIT_COMMIT_ID,\
+CAMELCASE
+
+tmpfile=$(mktemp)
+
+./scripts/checkpatch.pl --strict --ignore=$IGNORED -g HEAD | tee $tmpfile
+
+grep 'total: 0 errors, 0 warnings, 0 checks' $tmpfile
+ret=$?
+
+# return 250 (warning) if there are not errors
+[ $ret -ne 0 ] && grep -P 'total: 0 errors, \d+ warnings, \d+ checks' $tmpfile && ret=250
+
+if [ $ret -ne 0 ]; then
+        grep '\(WARNING\|ERROR\|CHECK\): ' $tmpfile | LC_COLLATE=C sort -u
+else
+        grep 'total: ' $tmpfile | LC_COLLATE=C sort -u
+fi
+
+rm $tmpfile
+
+exit $ret
+
+# ./scripts/checkpatch.pl --ignore=SPACING_CAST,LONG_LINE,LONG_LINE_COMMENT,LONG_LINE_STRING,LINE_SPACING_STRUCT,FILE_PATH_CHANGES,CAMELCASE,OPEN_ENDED_LINE,AVOID_EXTERNS_HEADER,UNCOMMENTED_DEFINITION

--- a/.github/scripts/patches/dtb_warn_rv64.sh
+++ b/.github/scripts/patches/dtb_warn_rv64.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Netronome Systems, Inc.
+
+# Modified tests/patch/build_defconfig_warn.sh for RISC-V builds
+
+tmpfile_o=$(mktemp)
+tmpfile_n=$(mktemp)
+
+tmpdir_o=$(mktemp -d)
+tmpdir_n=$(mktemp -d)
+
+rc=0
+
+echo "Redirect to $tmpfile_o and $tmpfile_n"
+
+HEAD=$(git rev-parse HEAD)
+
+echo "Tree base:"
+git log -1 --pretty='%h ("%s")' HEAD~
+
+git checkout -q HEAD~
+
+echo "Building the tree before the patch"
+
+make -C . O=$tmpdir_o ARCH=riscv CROSS_COMPILE=riscv64-linux- \
+        defconfig
+
+make -C . O=$tmpdir_o ARCH=riscv CROSS_COMPILE=riscv64-linux- \
+        dtbs_check W=1 -j$(nproc) \
+        2> >(tee $tmpfile_o)
+
+incumbent=$(cat $tmpfile_o | grep -v "From schema" | wc -l)
+
+echo "Building the tree with the patch"
+
+git checkout -q $HEAD
+
+make -C . O=$tmpdir_n ARCH=riscv CROSS_COMPILE=riscv64-linux- \
+        defconfig
+
+make -C . O=$tmpdir_n ARCH=riscv CROSS_COMPILE=riscv64-linux- \
+        dtbs_check W=1 -j$(nproc) \
+        2> >(tee $tmpfile_n) || rc=1
+
+current=$(cat $tmpfile_n | grep -v "From schema" | wc -l)
+
+if [ $current -gt $incumbent ]; then
+        echo "Errors and warnings before: $incumbent this patch: $current"
+        echo "New errors added"
+        sed -i 's|^.*arch|arch|g' $tmpfile_o
+        sed -i 's|^.*arch|arch|g' $tmpfile_n
+        diff -U 0 $tmpfile_o $tmpfile_n
+
+        rc=1
+fi
+
+rm -rf $tmpdir_o $tmpdir_n $tmpfile_o $tmpfile_n
+
+exit $rc

--- a/.github/scripts/patches/header_inline.sh
+++ b/.github/scripts/patches/header_inline.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2020 Facebook
+
+inlines=$(
+    git show -- '*.h' | grep -C1 -P '^\+static (?!(__always_)?inline).*\(';
+    git show -- '*.h' | grep -C1 -P '^\+(static )?(?!(__always_)?inline )((unsigned|long|short) )*(char|bool|void|int|u[0-9]*) [0-9A-Za-z_]*\(.*\) *{'
+       )
+
+if [ -z "$inlines" ]; then
+        exit 0
+fi
+
+msg="Detected static functions without inline keyword in header files:"
+echo -e "$msg\n$inlines"
+count=$( (echo "---"; echo "$inlines") | grep '^---$' | wc -l)
+echo "$msg $count"
+exit 1

--- a/.github/scripts/patches/kdoc.sh
+++ b/.github/scripts/patches/kdoc.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Netronome Systems, Inc.
+# Copyright (c) 2020 Facebook
+
+tmpfile_o=$(mktemp)
+tmpfile_n=$(mktemp)
+rc=0
+
+files=$(git show --pretty="" --name-only HEAD)
+
+HEAD=$(git rev-parse HEAD)
+
+echo "Checking the tree before the patch"
+git checkout -q HEAD~
+./scripts/kernel-doc -none $files 2> >(tee $tmpfile_o)
+
+incumbent=$(grep -v 'Error: Cannot open file ' $tmpfile_o | wc -l)
+
+echo "Checking the tree with the patch"
+
+git checkout -q $HEAD
+./scripts/kernel-doc -none $files 2> >(tee $tmpfile_n)
+
+current=$(grep -v 'Error: Cannot open file ' $tmpfile_n | wc -l)
+
+
+if [ $current -gt $incumbent ]; then
+        echo "Errors and warnings before: $incumbent this patch: $current"
+        echo "New warnings added"
+        diff $tmpfile_o $tmpfile_n
+
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
+
+        grep -i "\(warn\|error\)" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          >$tmpfile_fo
+        grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          >$tmpfile_fn
+
+        diff $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        rc=1
+fi
+
+rm $tmpfile_o $tmpfile_n
+
+exit $rc

--- a/.github/scripts/patches/module_param.sh
+++ b/.github/scripts/patches/module_param.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2020 Facebook
+
+params=$(git show | grep -i '^\+.*module_param')
+new_params=$(git show | grep -ic '^\+.*module_param')
+old_params=$(git show | grep -ic '^\-.*module_param')
+
+echo "Was $old_params now: $new_params"
+
+if [ -z "$params" ]; then
+        exit 0
+fi
+
+echo -e "Detected module_param\n$params"
+if [ $new_params -eq $old_params ]; then
+        exit 250
+fi
+
+exit 1

--- a/.github/scripts/patches/verify_fixes.sh
+++ b/.github/scripts/patches/verify_fixes.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Stephen Rothwell <sfr@canb.auug.org.au>
+# Copyright (C) 2019 Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+# Copyright (c) 2020 Facebook
+#
+# Verify that the "Fixes:" tag is correct in a kernel commit
+#
+# usage:
+#	verify_fixes.sh GIT_RANGE
+#
+# To test just the HEAD commit do:
+#	verify_fixes.sh HEAD^..HEAD
+#
+#
+# Thanks to Stephen Rothwell <sfr@canb.auug.org.au> for the majority of this code
+#
+
+# Only thing you might want to change here, the location of where Linus's git
+# tree is on your system:
+
+##########################################
+# No need to touch anything below here
+
+split_re='^([Cc][Oo][Mm][Mm][Ii][Tt])?[[:space:]]*([[:xdigit:]]{5,})([[:space:]]*)(.*)$'
+nl=$'\n'
+tab=$'\t'
+
+help()
+{
+	echo "error, git range not found"
+	echo "usage:"
+	echo "	$0 GIT_RANGE"
+	exit 1
+}
+
+# Strip the leading and training spaces from a string
+strip_spaces()
+{
+	[[ "$1" =~ ^[[:space:]]*(.*[^[:space:]])[[:space:]]*$ ]]
+	echo "${BASH_REMATCH[1]}"
+}
+
+verify_fixes()
+{
+	git_range=$1
+	error=0
+	commits=$(git rev-list --no-merges -i --grep='^[[:space:]]*Fixes:' "${git_range}")
+	if [ -z "$commits" ]; then
+                echo "No Fixes tag"
+	        return 0
+	fi
+
+	for c in $commits; do
+
+		commit_log=$(git log -1 --format='%h ("%s")' "$c")
+#			commit_msg="In commit:
+#	$commit_log
+#"
+			commit_msg="Commit: $commit_log
+"
+
+		fixes_lines=$(git log -1 --format='%B' "$c" |
+				grep -i '^[[:space:]]*Fixes:')
+
+		while read -r fline; do
+			[[ "$fline" =~ ^[[:space:]]*[Ff][Ii][Xx][Ee][Ss]:[[:space:]]*(.*)$ ]]
+			f="${BASH_REMATCH[1]}"
+#			fixes_msg="	Fixes tag:
+#		$fline
+#	Has these problem(s):
+#"
+			fixes_msg="	Fixes tag: $fline
+	Has these problem(s):
+"
+			sha=
+			subject=
+			msg=
+
+			if git log -1 --format='%B' "$c" | tr '\n' '#' | grep -qF "##$fline##"; then
+				msg="${msg:+${msg}${nl}}${tab}${tab}- empty lines surround the Fixes tag"
+				error=$(( error + 1 ))
+			fi
+
+			if [[ "$f" =~ $split_re ]]; then
+				first="${BASH_REMATCH[1]}"
+				sha="${BASH_REMATCH[2]}"
+				spaces="${BASH_REMATCH[3]}"
+				subject="${BASH_REMATCH[4]}"
+				if [ "$first" ]; then
+					msg="${msg:+${msg}${nl}}${tab}${tab}- leading word '$first' unexpected"
+					error=$(( error + 1 ))
+				fi
+				if [ -z "$subject" ]; then
+					msg="${msg:+${msg}${nl}}${tab}${tab}- missing subject"
+					error=$(( error + 1 ))
+				elif [ -z "$spaces" ]; then
+					msg="${msg:+${msg}${nl}}${tab}${tab}- missing space between the SHA1 and the subject"
+					error=$(( error + 1 ))
+				fi
+			else
+				printf '%s%s\t\t- %s\n' "$commit_msg" "$fixes_msg" 'No SHA1 recognised'
+				error=$(( error + 1 ))
+				commit_msg=''
+				continue
+			fi
+			if ! git rev-parse -q --verify "$sha" >/dev/null; then
+				printf '%s%s\t\t- %s\n' "$commit_msg" "$fixes_msg" 'Target SHA1 does not exist'
+				error=$(( error + 1 ))
+				commit_msg=''
+				continue
+			fi
+
+			if [ "${#sha}" -lt 12 ]; then
+				msg="${msg:+${msg}${nl}}${tab}${tab}- SHA1 should be at least 12 digits long${nl}${tab}${tab}  Can be fixed by setting core.abbrev to 12 (or more) or (for git v2.11${nl}${tab}${tab}  or later) just making sure it is not set (or set to \"auto\")."
+				error=$(( error + 1 ))
+			fi
+			# reduce the subject to the part between () if there
+			if [[ "$subject" =~ ^\((.*)\) ]]; then
+				subject="${BASH_REMATCH[1]}"
+			elif [[ "$subject" =~ ^\((.*) ]]; then
+				subject="${BASH_REMATCH[1]}"
+				msg="${msg:+${msg}${nl}}${tab}${tab}- Subject has leading but no trailing parentheses"
+				error=$(( error + 1 ))
+			fi
+
+			# strip matching quotes at the start and end of the subject
+			# the unicode characters in the classes are
+			# U+201C LEFT DOUBLE QUOTATION MARK
+			# U+201D RIGHT DOUBLE QUOTATION MARK
+			# U+2018 LEFT SINGLE QUOTATION MARK
+			# U+2019 RIGHT SINGLE QUOTATION MARK
+			re1=$'^[\"\u201C](.*)[\"\u201D]$'
+			re2=$'^[\'\u2018](.*)[\'\u2019]$'
+			re3=$'^[\"\'\u201C\u2018](.*)$'
+			if [[ "$subject" =~ $re1 ]]; then
+				subject="${BASH_REMATCH[1]}"
+			elif [[ "$subject" =~ $re2 ]]; then
+				subject="${BASH_REMATCH[1]}"
+			elif [[ "$subject" =~ $re3 ]]; then
+				subject="${BASH_REMATCH[1]}"
+				msg="${msg:+${msg}${nl}}${tab}${tab}- Subject has leading but no trailing quotes"
+				error=$(( error + 1 ))
+			fi
+
+			subject=$(strip_spaces "$subject")
+
+			target_subject=$(git log -1 --format='%s' "$sha")
+			target_subject=$(strip_spaces "$target_subject")
+
+			# match with ellipses
+			case "$subject" in
+			*...)	subject="${subject%...}"
+				target_subject="${target_subject:0:${#subject}}"
+				;;
+			...*)	subject="${subject#...}"
+				target_subject="${target_subject: -${#subject}}"
+				;;
+			*\ ...\ *)
+				s1="${subject% ... *}"
+				s2="${subject#* ... }"
+				subject="$s1 $s2"
+				t1="${target_subject:0:${#s1}}"
+				t2="${target_subject: -${#s2}}"
+				target_subject="$t1 $t2"
+				;;
+			esac
+			subject=$(strip_spaces "$subject")
+			target_subject=$(strip_spaces "$target_subject")
+
+			if [ "$subject" != "${target_subject:0:${#subject}}" ]; then
+				msg="${msg:+${msg}${nl}}${tab}${tab}- Subject does not match target commit subject${nl}${tab}${tab}  Just use${nl}${tab}${tab}${tab}git log -1 --format='Fixes: %h (\"%s\")'"
+				error=$(( error + 1 ))
+			fi
+			lsha=$(git rev-parse -q --verify "$sha")
+			if [ -z "$lsha" ]; then
+				count=$(git rev-list --count "$sha".."$c")
+				if [ "$count" -eq 0 ]; then
+					msg="${msg:+${msg}${nl}}${tab}${tab}- Target is not an ancestor of this commit"
+					error=$(( error + 1 ))
+				fi
+			fi
+
+			if [ "$msg" ]; then
+				printf '%s%s%s\n' "$commit_msg" "$fixes_msg" "$msg"
+				commit_msg=''
+				# Make sure we don't accidentally miss anything.
+				if [ $error -eq 0 ]; then
+					echo 'Whoops! $error out of sync with $msg'
+					error=1
+				fi
+			fi
+		done <<< "$fixes_lines"
+	done
+
+if [ ${error} -ne 0 ] ; then
+		echo "Problems with Fixes tag: $error"
+		exit 1
+	fi
+	echo "Fixes tag looks correct"
+	return 0
+}
+
+git_range="HEAD~..HEAD"
+
+if [ "${git_range}" == "" ] ; then
+	help
+fi
+
+verify_fixes "${git_range}"
+exit 0

--- a/.github/scripts/patches/verify_signedoff.sh
+++ b/.github/scripts/patches/verify_signedoff.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 Stephen Rothwell <sfr@canb.auug.org.au>
+# Copyright (C) 2019 Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+#
+# Verify that the signed-off-by chain looks correct for a range of git commits.
+#
+# usage:
+#	verify_signedoff.sh GIT_RANGE
+#
+# To test just the HEAD commit do:
+#	verify_signedoff.sh HEAD^..HEAD
+#
+#
+# Thanks to Stephen Rothwell <sfr@canb.auug.org.au> for the majority of this code
+#
+
+help()
+{
+	echo "error, git range not found"
+	echo "usage:"
+	echo "	$0 GIT_RANGE"
+	exit 1
+}
+
+verify_signedoff()
+{
+	git_range=$1
+	error=false
+	for c in $(git rev-list --no-merges "${git_range}"); do
+		ae=$(git log -1 --format='%ae' "$c")
+		aE=$(git log -1 --format='%aE' "$c")
+		an=$(git log -1 --format='%an' "$c")
+		aN=$(git log -1 --format='%aN' "$c")
+		ce=$(git log -1 --format='%ce' "$c")
+		cE=$(git log -1 --format='%cE' "$c")
+		cn=$(git log -1 --format='%cn' "$c")
+		cN=$(git log -1 --format='%cN' "$c")
+		sob=$(git log -1 --format='%b' "$c" | grep -i '^[[:space:]]*Signed-off-by:')
+
+		am=false
+		cm=false
+		grep -i -q "<$ae>" <<<"$sob" ||
+			grep -i -q "<$aE>" <<<"$sob" ||
+			grep -i -q ":[[:space:]]*${an}[[:space:]]*<" <<<"$sob" ||
+			grep -i -q ":[[:space:]]*${aN}[[:space:]]*<" <<<"$sob" ||
+			am=true
+		grep -i -q "<$ce>" <<<"$sob" ||
+			grep -i -q "<$cE>" <<<"$sob" ||
+			grep -i -q ":[[:space:]]*${cn}[[:space:]]*<" <<<"$sob" ||
+			grep -i -q ":[[:space:]]*${cN}[[:space:]]*<" <<<"$sob" ||
+			cm=true
+
+		if "$am" || "$cm"; then
+			printf "Commit %s\n" "$(git show -s --abbrev-commit --abbrev=12 --pretty=format:"%h (\"%s\")%n" "${c}")"
+			"$am" && printf "\tauthor Signed-off-by missing\n"
+			"$cm" && printf "\tcommitter Signed-off-by missing\n"
+			printf "\tauthor email:    %s\n" "$ae"
+			printf "\tcommitter email: %s\n"  "$ce"
+			readarray -t s <<< "${sob}"
+			printf "\t%s\n" "${s[@]}"
+			printf "\n"
+			error=true
+		fi
+	done
+	if "$error"; then
+		echo "Errors in tree with Signed-off-by, please fix!"
+		exit 1
+	fi
+        echo "Signed-off-by tag matches author and committer"
+}
+
+git_range="HEAD~..HEAD"
+
+if [ "${git_range}" == "" ] ; then
+	help
+fi
+
+verify_signedoff "${git_range}"
+exit 0

--- a/.github/scripts/series.sh
+++ b/.github/scripts/series.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+d=$(dirname "${BASH_SOURCE[0]}")
+
+. ${d}/helpers.sh
+
+rc=0
+tcnt=1
+tests=( $(ls ${d}/series/*.sh) )
+for i in "${tests[@]}"; do
+    git reset --hard HEAD >/dev/null
+    msg="Test ${tcnt}/${#tests[@]}: ${i}"
+    echo "::group::${msg}"
+    testrc=0
+    bash ${i} || testrc=1
+    echo "::endgroup::"
+    if (( $testrc )); then
+        rc=1
+        echo "::error::FAIL ${msg}"
+    else
+        echo "::notice::OK ${msg}"
+    fi
+    tcnt=$(( tcnt + 1 ))
+done
+
+exit $rc

--- a/.github/scripts/setup-github-ubuntu.sh
+++ b/.github/scripts/setup-github-ubuntu.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+arch=$(uname -m)
+case ${arch} in
+
+  "x86_64")
+    debarch="amd64"
+    ;;
+
+  "aarch64")
+    debarch="arm64"
+    ;;
+esac
+
+
+apt-get update && apt-get install --yes --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg
+
+# Add additional packages here.
+apt-get update && apt-get install --yes --no-install-recommends \
+    arch-test \
+    autoconf \
+    automake \
+    autotools-dev \
+    bash-completion \
+    bc \
+    binfmt-support \
+    bison \
+    bsdmainutils \
+    build-essential \
+    cpio \
+    curl \
+    diffstat \
+    flex \
+    g++-riscv64-linux-gnu \
+    gawk \
+    gcc-riscv64-linux-gnu \
+    gdb \
+    gettext \
+    git \
+    git-lfs \
+    gperf \
+    groff \
+    less \
+    libelf-dev \
+    liburing-dev \
+    lsb-release \
+    mmdebstrap \
+    ninja-build \
+    patchutils \
+    perl \
+    pkg-config \
+    psmisc \
+    python-is-python3 \
+    python3-venv \
+    qemu-user-static \
+    rsync \
+    ruby \
+    ssh \
+    strace \
+    texinfo \
+    traceroute \
+    unzip \
+    vim \
+    zlib1g-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg \
+    cmake \
+    libdw-dev \
+    libssl-dev \
+    python3-docutils \
+    kmod \
+    swig \
+    python3-dev \
+    ccache \
+    pipx
+
+echo "deb [arch=${debarch}] http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" >> /etc/apt/sources.list.d/llvm.list
+
+# wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+cat <<EOF > /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.4.12 (GNU/Linux)
+
+mQINBFE9lCwBEADi0WUAApM/mgHJRU8lVkkw0CHsZNpqaQDNaHefD6Rw3S4LxNmM
+EZaOTkhP200XZM8lVdbfUW9xSjA3oPldc1HG26NjbqqCmWpdo2fb+r7VmU2dq3NM
+R18ZlKixiLDE6OUfaXWKamZsXb6ITTYmgTO6orQWYrnW6ckYHSeaAkW0wkDAryl2
+B5v8aoFnQ1rFiVEMo4NGzw4UX+MelF7rxaaregmKVTPiqCOSPJ1McC1dHFN533FY
+Wh/RVLKWo6npu+owtwYFQW+zyQhKzSIMvNujFRzhIxzxR9Gn87MoLAyfgKEzrbbT
+DhqqNXTxS4UMUKCQaO93TzetX/EBrRpJj+vP640yio80h4Dr5pAd7+LnKwgpTDk1
+G88bBXJAcPZnTSKu9I2c6KY4iRNbvRz4i+ZdwwZtdW4nSdl2792L7Sl7Nc44uLL/
+ZqkKDXEBF6lsX5XpABwyK89S/SbHOytXv9o4puv+65Ac5/UShspQTMSKGZgvDauU
+cs8kE1U9dPOqVNCYq9Nfwinkf6RxV1k1+gwtclxQuY7UpKXP0hNAXjAiA5KS5Crq
+7aaJg9q2F4bub0mNU6n7UI6vXguF2n4SEtzPRk6RP+4TiT3bZUsmr+1ktogyOJCc
+Ha8G5VdL+NBIYQthOcieYCBnTeIH7D3Sp6FYQTYtVbKFzmMK+36ERreL/wARAQAB
+tD1TeWx2ZXN0cmUgTGVkcnUgLSBEZWJpYW4gTExWTSBwYWNrYWdlcyA8c3lsdmVz
+dHJlQGRlYmlhbi5vcmc+iQI4BBMBAgAiBQJRPZQsAhsDBgsJCAcDAgYVCAIJCgsE
+FgIDAQIeAQIXgAAKCRAVz00Yr090Ibx+EADArS/hvkDF8juWMXxh17CgR0WZlHCC
+9CTBWkg5a0bNN/3bb97cPQt/vIKWjQtkQpav6/5JTVCSx2riL4FHYhH0iuo4iAPR
+udC7Cvg8g7bSPrKO6tenQZNvQm+tUmBHgFiMBJi92AjZ/Qn1Shg7p9ITivFxpLyX
+wpmnF1OKyI2Kof2rm4BFwfSWuf8Fvh7kDMRLHv+MlnK/7j/BNpKdozXxLcwoFBmn
+l0WjpAH3OFF7Pvm1LJdf1DjWKH0Dc3sc6zxtmBR/KHHg6kK4BGQNnFKujcP7TVdv
+gMYv84kun14pnwjZcqOtN3UJtcx22880DOQzinoMs3Q4w4o05oIF+sSgHViFpc3W
+R0v+RllnH05vKZo+LDzc83DQVrdwliV12eHxrMQ8UYg88zCbF/cHHnlzZWAJgftg
+hB08v1BKPgYRUzwJ6VdVqXYcZWEaUJmQAPuAALyZESw94hSo28FAn0/gzEc5uOYx
+K+xG/lFwgAGYNb3uGM5m0P6LVTfdg6vDwwOeTNIExVk3KVFXeSQef2ZMkhwA7wya
+KJptkb62wBHFE+o9TUdtMCY6qONxMMdwioRE5BYNwAsS1PnRD2+jtlI0DzvKHt7B
+MWd8hnoUKhMeZ9TNmo+8CpsAtXZcBho0zPGz/R8NlJhAWpdAZ1CmcPo83EW86Yq7
+BxQUKnNHcwj2ebkCDQRRPZQsARAA4jxYmbTHwmMjqSizlMJYNuGOpIidEdx9zQ5g
+zOr431/VfWq4S+VhMDhs15j9lyml0y4ok215VRFwrAREDg6UPMr7ajLmBQGau0Fc
+bvZJ90l4NjXp5p0NEE/qOb9UEHT7EGkEhaZ1ekkWFTWCgsy7rRXfZLxB6sk7pzLC
+DshyW3zjIakWAnpQ5j5obiDy708pReAuGB94NSyb1HoW/xGsGgvvCw4r0w3xPStw
+F1PhmScE6NTBIfLliea3pl8vhKPlCh54Hk7I8QGjo1ETlRP4Qll1ZxHJ8u25f/ta
+RES2Aw8Hi7j0EVcZ6MT9JWTI83yUcnUlZPZS2HyeWcUj+8nUC8W4N8An+aNps9l/
+21inIl2TbGo3Yn1JQLnA1YCoGwC34g8QZTJhElEQBN0X29ayWW6OdFx8MDvllbBV
+ymmKq2lK1U55mQTfDli7S3vfGz9Gp/oQwZ8bQpOeUkc5hbZszYwP4RX+68xDPfn+
+M9udl+qW9wu+LyePbW6HX90LmkhNkkY2ZzUPRPDHZANU5btaPXc2H7edX4y4maQa
+xenqD0lGh9LGz/mps4HEZtCI5CY8o0uCMF3lT0XfXhuLksr7Pxv57yue8LLTItOJ
+d9Hmzp9G97SRYYeqU+8lyNXtU2PdrLLq7QHkzrsloG78lCpQcalHGACJzrlUWVP/
+fN3Ht3kAEQEAAYkCHwQYAQIACQUCUT2ULAIbDAAKCRAVz00Yr090IbhWEADbr50X
+OEXMIMGRLe+YMjeMX9NG4jxs0jZaWHc/WrGR+CCSUb9r6aPXeLo+45949uEfdSsB
+pbaEdNWxF5Vr1CSjuO5siIlgDjmT655voXo67xVpEN4HhMrxugDJfCa6z97P0+ML
+PdDxim57uNqkam9XIq9hKQaurxMAECDPmlEXI4QT3eu5qw5/knMzDMZj4Vi6hovL
+wvvAeLHO/jsyfIdNmhBGU2RWCEZ9uo/MeerPHtRPfg74g+9PPfP6nyHD2Wes6yGd
+oVQwtPNAQD6Cj7EaA2xdZYLJ7/jW6yiPu98FFWP74FN2dlyEA2uVziLsfBrgpS4l
+tVOlrO2YzkkqUGrybzbLpj6eeHx+Cd7wcjI8CalsqtL6cG8cUEjtWQUHyTbQWAgG
+5VPEgIAVhJ6RTZ26i/G+4J8neKyRs4vz+57UGwY6zI4AB1ZcWGEE3Bf+CDEDgmnP
+LSwbnHefK9IljT9XU98PelSryUO/5UPw7leE0akXKB4DtekToO226px1VnGp3Bov
+1GBGvpHvL2WizEwdk+nfk8LtrLzej+9FtIcq3uIrYnsac47Pf7p0otcFeTJTjSq3
+krCaoG4Hx0zGQG2ZFpHrSrZTVy6lxvIdfi0beMgY6h78p6M9eYZHQHc02DjFkQXN
+bXb5c6gCHESH5PXwPU4jQEE7Ib9J6sbk7ZT2Mw==
+=j+4q
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
+apt-get update
+if [[ $debarch == "arm64" ]]; then
+    apt-get install --yes clang-18 llvm-18 lld-18
+else
+    apt-get install --yes clang llvm lld
+fi
+
+# Ick. BPF requires pahole "supernew" to work
+cd $(mktemp -d) && git clone https://git.kernel.org/pub/scm/devel/pahole/pahole.git && \
+    cd pahole && mkdir build && cd build && cmake -D__LIB=lib .. && make install
+
+dpkg --add-architecture riscv64
+if [[ $debarch == "arm64" ]]; then
+    sed -i "s/^deb/deb [arch=${debarch}]/" /etc/apt/sources.list
+    cat <<EOF >> /etc/apt/sources.list
+deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted multiverse universe
+deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main
+deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports jammy-security main
+EOF
+fi
+
+apt-get update
+
+apt-get install --yes --no-install-recommends \
+    libasound2-dev:riscv64 \
+    libc6-dev:riscv64 \
+    libcap-dev:riscv64 \
+    libcap-ng-dev:riscv64 \
+    libelf-dev:riscv64 \
+    libfuse-dev:riscv64 \
+    libhugetlbfs-dev:riscv64 \
+    libmnl-dev:riscv64 \
+    libnuma-dev:riscv64 \
+    libpopt-dev:riscv64 \
+    libssl-dev:riscv64 \
+    liburing-dev:riscv64
+
+export PIPX_HOME=/root/.local/pipx/venvs
+export PIPX_BIN_DIR=/root/.local/bin
+pipx install tuxmake
+pipx install dtschema
+
+echo 'export PATH=${PATH}:/root/.local/bin' >> ~/.bashrc
+
+if [[ $debarch == "amd64" ]]; then
+    exit 0
+fi
+
+register_clang_version() {
+    local version=$1
+    local priority=$2
+
+    update-alternatives \
+        --install /usr/bin/llvm-config       llvm-config      /usr/bin/llvm-config-${version} ${priority} \
+        --slave   /usr/bin/llvm-ar           llvm-ar          /usr/bin/llvm-ar-${version} \
+        --slave   /usr/bin/llvm-as           llvm-as          /usr/bin/llvm-as-${version} \
+        --slave   /usr/bin/llvm-bcanalyzer   llvm-bcanalyzer  /usr/bin/llvm-bcanalyzer-${version} \
+        --slave   /usr/bin/llvm-cov          llvm-cov         /usr/bin/llvm-cov-${version} \
+        --slave   /usr/bin/llvm-diff         llvm-diff        /usr/bin/llvm-diff-${version} \
+        --slave   /usr/bin/llvm-dis          llvm-dis         /usr/bin/llvm-dis-${version} \
+        --slave   /usr/bin/llvm-dwarfdump    llvm-dwarfdump   /usr/bin/llvm-dwarfdump-${version} \
+        --slave   /usr/bin/llvm-extract      llvm-extract     /usr/bin/llvm-extract-${version} \
+        --slave   /usr/bin/llvm-link         llvm-link        /usr/bin/llvm-link-${version} \
+        --slave   /usr/bin/llvm-mc           llvm-mc          /usr/bin/llvm-mc-${version} \
+        --slave   /usr/bin/llvm-mcmarkup     llvm-mcmarkup    /usr/bin/llvm-mcmarkup-${version} \
+        --slave   /usr/bin/llvm-nm           llvm-nm          /usr/bin/llvm-nm-${version} \
+        --slave   /usr/bin/llvm-objdump      llvm-objdump     /usr/bin/llvm-objdump-${version} \
+        --slave   /usr/bin/llvm-objcopy      llvm-objcopy     /usr/bin/llvm-objcopy-${version} \
+        --slave   /usr/bin/llvm-ranlib       llvm-ranlib      /usr/bin/llvm-ranlib-${version} \
+        --slave   /usr/bin/llvm-readobj      llvm-readobj     /usr/bin/llvm-readobj-${version} \
+        --slave   /usr/bin/llvm-rtdyld       llvm-rtdyld      /usr/bin/llvm-rtdyld-${version} \
+        --slave   /usr/bin/llvm-size         llvm-size        /usr/bin/llvm-size-${version} \
+        --slave   /usr/bin/llvm-strip        llvm-strip       /usr/bin/llvm-strip-${version} \
+        --slave   /usr/bin/llvm-readelf      llvm-readelf     /usr/bin/llvm-readelf-${version} \
+        --slave   /usr/bin/llvm-stress       llvm-stress      /usr/bin/llvm-stress-${version} \
+        --slave   /usr/bin/llvm-symbolizer   llvm-symbolizer  /usr/bin/llvm-symbolizer-${version} \
+        --slave   /usr/bin/llvm-tblgen       llvm-tblgen      /usr/bin/llvm-tblgen-${version}
+
+    update-alternatives \
+        --install /usr/bin/clang                 clang                 /usr/bin/clang-${version} ${priority} \
+        --slave   /usr/bin/clang++               clang++               /usr/bin/clang++-${version}  \
+        --slave   /usr/bin/asan_symbolize        asan_symbolize        /usr/bin/asan_symbolize-${version} \
+        --slave   /usr/bin/c-index-test          c-index-test          /usr/bin/c-index-test-${version} \
+        --slave   /usr/bin/clang-check           clang-check           /usr/bin/clang-check-${version} \
+        --slave   /usr/bin/clang-cl              clang-cl              /usr/bin/clang-cl-${version} \
+        --slave   /usr/bin/clang-cpp             clang-cpp             /usr/bin/clang-cpp-${version} \
+        --slave   /usr/bin/clang-format          clang-format          /usr/bin/clang-format-${version} \
+        --slave   /usr/bin/clang-format-diff     clang-format-diff     /usr/bin/clang-format-diff-${version} \
+        --slave   /usr/bin/clang-import-test     clang-import-test     /usr/bin/clang-import-test-${version} \
+        --slave   /usr/bin/clang-include-fixer   clang-include-fixer   /usr/bin/clang-include-fixer-${version} \
+        --slave   /usr/bin/clang-offload-bundler clang-offload-bundler /usr/bin/clang-offload-bundler-${version} \
+        --slave   /usr/bin/clang-query           clang-query           /usr/bin/clang-query-${version} \
+        --slave   /usr/bin/clang-rename          clang-rename          /usr/bin/clang-rename-${version} \
+        --slave   /usr/bin/clang-reorder-fields  clang-reorder-fields  /usr/bin/clang-reorder-fields-${version} \
+        --slave   /usr/bin/clang-tidy            clang-tidy            /usr/bin/clang-tidy-${version} \
+        --slave   /usr/bin/lldb                  lldb                  /usr/bin/lldb-${version} \
+        --slave   /usr/bin/lldb-server           lldb-server           /usr/bin/lldb-server-${version} \
+        --slave   /usr/bin/ld.lld                lld                   /usr/bin/ld.lld-${version}
+}
+
+register_clang_version 18 1

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: linux-riscv-ci-patches
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+on: pull_request
+
+jobs:
+  build-patches:
+    runs-on: 'self-hosted'
+    timeout-minutes: 50400 # 35 days
+    container:
+      image: ghcr.io/linux-riscv/pw-builder:latest
+      volumes:
+        - /disk-1/var/lib/ghrunner:/ccache
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+      - name: Checkout git
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Run checks
+        run: |
+          bash .github/scripts/patches.sh

--- a/.github/workflows/series.yml
+++ b/.github/workflows/series.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2023 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: linux-riscv-ci
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+on: workflow_dispatch
+
+jobs:
+  build-series:
+    runs-on: 'self-hosted'
+    container:
+      image: ghcr.io/linux-riscv/pw-builder:latest
+      volumes:
+        - /disk-1/var/lib/ghrunner:/ccache
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+      - name: Checkout git
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run checks
+        run: |
+          bash .github/scripts/series.sh
+          

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -643,6 +643,15 @@ config THREAD_SIZE_ORDER
 	  Specify the Pages of thread stack size (from 4KB to 64KB), which also
 	  affects irq stack size, which is equal to thread stack size.
 
+config RISCV_MISALIGNED
+	bool "Support misaligned load/store traps for kernel and userspace"
+	select SYSCTL_ARCH_UNALIGN_ALLOW
+	default y
+	help
+	  Say Y here if you want the kernel to embed support for misaligned
+	  load/store for both kernel and userspace. When disable, misaligned
+	  accesses will generate SIGBUS in userspace and panic in kernel.
+
 endmenu # "Platform type"
 
 menu "Kernel features"

--- a/arch/riscv/include/asm/cpufeature.h
+++ b/arch/riscv/include/asm/cpufeature.h
@@ -33,4 +33,22 @@ extern struct riscv_isainfo hart_isa[NR_CPUS];
 int check_unaligned_access(void *unused);
 void riscv_user_isa_enable(void);
 
+#ifdef CONFIG_RISCV_MISALIGNED
+bool unaligned_ctl_available(void);
+bool check_unaligned_access_emulated(int cpu);
+void unaligned_emulation_finish(void);
+#else
+static inline bool unaligned_ctl_available(void)
+{
+	return false;
+}
+
+static inline bool check_unaligned_access_emulated(int cpu)
+{
+	return false;
+}
+
+static inline void unaligned_emulation_finish(void) {}
+#endif
+
 #endif

--- a/arch/riscv/include/asm/cpufeature.h
+++ b/arch/riscv/include/asm/cpufeature.h
@@ -30,7 +30,7 @@ DECLARE_PER_CPU(long, misaligned_access_speed);
 /* Per-cpu ISA extensions. */
 extern struct riscv_isainfo hart_isa[NR_CPUS];
 
-void check_unaligned_access(int cpu);
+int check_unaligned_access(void *unused);
 void riscv_user_isa_enable(void);
 
 #endif

--- a/arch/riscv/include/asm/entry-common.h
+++ b/arch/riscv/include/asm/entry-common.h
@@ -8,4 +8,18 @@
 void handle_page_fault(struct pt_regs *regs);
 void handle_break(struct pt_regs *regs);
 
+#ifdef CONFIG_RISCV_MISALIGNED
+int handle_misaligned_load(struct pt_regs *regs);
+int handle_misaligned_store(struct pt_regs *regs);
+#else
+static inline int handle_misaligned_load(struct pt_regs *regs)
+{
+	return -1;
+}
+static inline int handle_misaligned_store(struct pt_regs *regs)
+{
+	return -1;
+}
+#endif
+
 #endif /* _ASM_RISCV_ENTRY_COMMON_H */

--- a/arch/riscv/include/asm/processor.h
+++ b/arch/riscv/include/asm/processor.h
@@ -8,6 +8,7 @@
 
 #include <linux/const.h>
 #include <linux/cache.h>
+#include <linux/prctl.h>
 
 #include <vdso/processor.h>
 
@@ -82,6 +83,7 @@ struct thread_struct {
 	unsigned long bad_cause;
 	unsigned long vstate_ctrl;
 	struct __riscv_v_ext_state vstate;
+	unsigned long align_ctl;
 };
 
 /* Whitelist the fstate from the task_struct for hardened usercopy */
@@ -94,6 +96,7 @@ static inline void arch_thread_struct_whitelist(unsigned long *offset,
 
 #define INIT_THREAD {					\
 	.sp = sizeof(init_stack) + (long)&init_stack,	\
+	.align_ctl = PR_UNALIGN_NOPRINT,		\
 }
 
 #define task_pt_regs(tsk)						\
@@ -133,6 +136,12 @@ extern unsigned long signal_minsigstksz __ro_after_init;
 extern long riscv_v_vstate_ctrl_set_current(unsigned long arg);
 extern long riscv_v_vstate_ctrl_get_current(void);
 #endif /* CONFIG_RISCV_ISA_V */
+
+extern int get_unalign_ctl(struct task_struct *tsk, unsigned long addr);
+extern int set_unalign_ctl(struct task_struct *tsk, unsigned int val);
+
+#define GET_UNALIGN_CTL(tsk, addr)	get_unalign_ctl((tsk), (addr))
+#define SET_UNALIGN_CTL(tsk, val)	set_unalign_ctl((tsk), (val))
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/riscv/kernel/Makefile
+++ b/arch/riscv/kernel/Makefile
@@ -59,7 +59,7 @@ obj-y	+= patch.o
 obj-y	+= probes/
 obj-$(CONFIG_MMU) += vdso.o vdso/
 
-obj-$(CONFIG_RISCV_M_MODE)	+= traps_misaligned.o
+obj-$(CONFIG_RISCV_MISALIGNED)	+= traps_misaligned.o
 obj-$(CONFIG_FPU)		+= fpu.o
 obj-$(CONFIG_RISCV_ISA_V)	+= vector.o
 obj-$(CONFIG_SMP)		+= smpboot.o

--- a/arch/riscv/kernel/cpufeature.c
+++ b/arch/riscv/kernel/cpufeature.c
@@ -557,9 +557,8 @@ unsigned long riscv_get_elf_hwcap(void)
 	return hwcap;
 }
 
-int check_unaligned_access(void *unused)
+void check_unaligned_access(int cpu)
 {
-	int cpu = smp_processor_id();
 	u64 start_cycles, end_cycles;
 	u64 word_cycles;
 	u64 byte_cycles;
@@ -573,7 +572,7 @@ int check_unaligned_access(void *unused)
 	page = alloc_pages(GFP_NOWAIT, get_order(MISALIGNED_BUFFER_SIZE));
 	if (!page) {
 		pr_warn("Can't alloc pages to measure memcpy performance");
-		return 0;
+		return;
 	}
 
 	/* Make an unaligned destination buffer. */
@@ -645,26 +644,15 @@ int check_unaligned_access(void *unused)
 
 out:
 	__free_pages(page, get_order(MISALIGNED_BUFFER_SIZE));
+}
+
+static int check_unaligned_access_boot_cpu(void)
+{
+	check_unaligned_access(0);
 	return 0;
 }
 
-static void check_unaligned_access_nonboot_cpu(void *param)
-{
-	if (smp_processor_id() != 0)
-		check_unaligned_access(param);
-}
-
-static int check_unaligned_access_all_cpus(void)
-{
-	/* Check everybody except 0, who stays behind to tend jiffies. */
-	on_each_cpu(check_unaligned_access_nonboot_cpu, NULL, 1);
-
-	/* Check core 0. */
-	smp_call_on_cpu(0, check_unaligned_access, NULL, true);
-	return 0;
-}
-
-arch_initcall(check_unaligned_access_all_cpus);
+arch_initcall(check_unaligned_access_boot_cpu);
 
 void riscv_user_isa_enable(void)
 {

--- a/arch/riscv/kernel/fpu.S
+++ b/arch/riscv/kernel/fpu.S
@@ -104,3 +104,124 @@ ENTRY(__fstate_restore)
 	csrc CSR_STATUS, t1
 	ret
 ENDPROC(__fstate_restore)
+
+#define get_f32(which) fmv.x.s a0, which; j 2f
+#define put_f32(which) fmv.s.x which, a1; j 2f
+#if __riscv_xlen == 64
+# define get_f64(which) fmv.x.d a0, which; j 2f
+# define put_f64(which) fmv.d.x which, a1; j 2f
+#else
+# define get_f64(which) fsd which, 0(a1); j 2f
+# define put_f64(which) fld which, 0(a1); j 2f
+#endif
+
+.macro fp_access_prologue
+	/*
+	 * Compute jump offset to store the correct FP register since we don't
+	 * have indirect FP register access
+	 */
+	sll t0, a0, 3
+	la t2, 1f
+	add t0, t0, t2
+	li t1, SR_FS
+	csrs CSR_STATUS, t1
+	jr t0
+1:
+.endm
+
+.macro fp_access_epilogue
+2:
+	csrc CSR_STATUS, t1
+	ret
+.endm
+
+#define fp_access_body(__access_func) \
+	__access_func(f0); \
+	__access_func(f1); \
+	__access_func(f2); \
+	__access_func(f3); \
+	__access_func(f4); \
+	__access_func(f5); \
+	__access_func(f6); \
+	__access_func(f7); \
+	__access_func(f8); \
+	__access_func(f9); \
+	__access_func(f10); \
+	__access_func(f11); \
+	__access_func(f12); \
+	__access_func(f13); \
+	__access_func(f14); \
+	__access_func(f15); \
+	__access_func(f16); \
+	__access_func(f17); \
+	__access_func(f18); \
+	__access_func(f19); \
+	__access_func(f20); \
+	__access_func(f21); \
+	__access_func(f22); \
+	__access_func(f23); \
+	__access_func(f24); \
+	__access_func(f25); \
+	__access_func(f26); \
+	__access_func(f27); \
+	__access_func(f28); \
+	__access_func(f29); \
+	__access_func(f30); \
+	__access_func(f31)
+
+
+#ifdef CONFIG_RISCV_MISALIGNED
+
+/*
+ * Disable compressed instructions set to keep a constant offset between FP
+ * load/store/move instructions
+ */
+.option norvc
+/*
+ * put_f32_reg - Set a FP register from a register containing the value
+ * a0 = FP register index to be set
+ * a1 = value to be loaded in the FP register
+ */
+SYM_FUNC_START(put_f32_reg)
+	fp_access_prologue
+	fp_access_body(put_f32)
+	fp_access_epilogue
+SYM_FUNC_END(put_f32_reg)
+
+/*
+ * get_f32_reg - Get a FP register value and return it
+ * a0 = FP register index to be retrieved
+ */
+SYM_FUNC_START(get_f32_reg)
+	fp_access_prologue
+	fp_access_body(get_f32)
+	fp_access_epilogue
+SYM_FUNC_END(get_f32_reg)
+
+/*
+ * put_f64_reg - Set a 64 bits FP register from a value or a pointer.
+ * a0 = FP register index to be set
+ * a1 = value/pointer to be loaded in the FP register (when xlen == 32 bits, we
+ * load the value to a pointer).
+ */
+SYM_FUNC_START(put_f64_reg)
+	fp_access_prologue
+	fp_access_body(put_f64)
+	fp_access_epilogue
+SYM_FUNC_END(put_f64_reg)
+
+/*
+ * put_f64_reg - Get a 64 bits FP register value and returned it or store it to
+ *	 	 a pointer.
+ * a0 = FP register index to be retrieved
+ * a1 = If xlen == 32, pointer which should be loaded with the FP register value
+ *	or unused if xlen == 64. In which case the FP register value is returned
+ *	through a0
+ */
+SYM_FUNC_START(get_f64_reg)
+	fp_access_prologue
+	fp_access_body(get_f64)
+	fp_access_epilogue
+SYM_FUNC_END(get_f64_reg)
+
+#endif /* CONFIG_RISCV_MISALIGNED */

--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -25,6 +25,7 @@
 #include <asm/thread_info.h>
 #include <asm/cpuidle.h>
 #include <asm/vector.h>
+#include <asm/cpufeature.h>
 
 register unsigned long gp_in_global __asm__("gp");
 
@@ -39,6 +40,23 @@ extern asmlinkage void ret_from_fork(void);
 void arch_cpu_idle(void)
 {
 	cpu_do_idle();
+}
+
+int set_unalign_ctl(struct task_struct *tsk, unsigned int val)
+{
+	if (!unaligned_ctl_available())
+		return -EINVAL;
+
+	tsk->thread.align_ctl = val;
+	return 0;
+}
+
+int get_unalign_ctl(struct task_struct *tsk, unsigned long adr)
+{
+	if (!unaligned_ctl_available())
+		return -EINVAL;
+
+	return put_user(tsk->thread.align_ctl, (unsigned long __user *)adr);
 }
 
 void __show_regs(struct pt_regs *regs)

--- a/arch/riscv/kernel/smpboot.c
+++ b/arch/riscv/kernel/smpboot.c
@@ -29,7 +29,6 @@
 #include <asm/cpufeature.h>
 #include <asm/cpu_ops.h>
 #include <asm/cpufeature.h>
-#include <asm/hwprobe.h>
 #include <asm/irq.h>
 #include <asm/mmu_context.h>
 #include <asm/numa.h>
@@ -249,15 +248,7 @@ asmlinkage __visible void smp_callin(void)
 
 	numa_add_cpu(curr_cpuid);
 	set_cpu_online(curr_cpuid, 1);
-
-	/*
-	 * Boot-time misaligned access speed measurements are done in parallel
-	 * in an initcall. Only measure here for hotplug.
-	 */
-	if ((system_state == SYSTEM_RUNNING) &&
-	    (per_cpu(misaligned_access_speed, curr_cpuid) == RISCV_HWPROBE_MISALIGNED_UNKNOWN)) {
-		check_unaligned_access(NULL);
-	}
+	check_unaligned_access(curr_cpuid);
 
 	if (has_vector()) {
 		if (riscv_v_setup_vsize())

--- a/arch/riscv/kernel/smpboot.c
+++ b/arch/riscv/kernel/smpboot.c
@@ -29,6 +29,7 @@
 #include <asm/cpufeature.h>
 #include <asm/cpu_ops.h>
 #include <asm/cpufeature.h>
+#include <asm/hwprobe.h>
 #include <asm/irq.h>
 #include <asm/mmu_context.h>
 #include <asm/numa.h>
@@ -248,7 +249,15 @@ asmlinkage __visible void smp_callin(void)
 
 	numa_add_cpu(curr_cpuid);
 	set_cpu_online(curr_cpuid, 1);
-	check_unaligned_access(curr_cpuid);
+
+	/*
+	 * Boot-time misaligned access speed measurements are done in parallel
+	 * in an initcall. Only measure here for hotplug.
+	 */
+	if ((system_state == SYSTEM_RUNNING) &&
+	    (per_cpu(misaligned_access_speed, curr_cpuid) == RISCV_HWPROBE_MISALIGNED_UNKNOWN)) {
+		check_unaligned_access(NULL);
+	}
 
 	if (has_vector()) {
 		if (riscv_v_setup_vsize())

--- a/arch/riscv/kernel/traps.c
+++ b/arch/riscv/kernel/traps.c
@@ -179,14 +179,6 @@ asmlinkage __visible __trap_section void do_trap_insn_illegal(struct pt_regs *re
 
 DO_ERROR_INFO(do_trap_load_fault,
 	SIGSEGV, SEGV_ACCERR, "load access fault");
-#ifndef CONFIG_RISCV_M_MODE
-DO_ERROR_INFO(do_trap_load_misaligned,
-	SIGBUS, BUS_ADRALN, "Oops - load address misaligned");
-DO_ERROR_INFO(do_trap_store_misaligned,
-	SIGBUS, BUS_ADRALN, "Oops - store (or AMO) address misaligned");
-#else
-int handle_misaligned_load(struct pt_regs *regs);
-int handle_misaligned_store(struct pt_regs *regs);
 
 asmlinkage __visible __trap_section void do_trap_load_misaligned(struct pt_regs *regs)
 {
@@ -229,7 +221,6 @@ asmlinkage __visible __trap_section void do_trap_store_misaligned(struct pt_regs
 		irqentry_nmi_exit(regs, state);
 	}
 }
-#endif
 DO_ERROR_INFO(do_trap_store_fault,
 	SIGSEGV, SEGV_ACCERR, "store (or AMO) access fault");
 DO_ERROR_INFO(do_trap_ecall_s,

--- a/arch/riscv/kernel/traps_misaligned.c
+++ b/arch/riscv/kernel/traps_misaligned.c
@@ -6,12 +6,16 @@
 #include <linux/init.h>
 #include <linux/mm.h>
 #include <linux/module.h>
+#include <linux/perf_event.h>
 #include <linux/irq.h>
 #include <linux/stringify.h>
 
 #include <asm/processor.h>
 #include <asm/ptrace.h>
 #include <asm/csr.h>
+#include <asm/entry-common.h>
+#include <asm/hwprobe.h>
+#include <asm/cpufeature.h>
 
 #define INSN_MATCH_LB			0x3
 #define INSN_MASK_LB			0x707f
@@ -151,53 +155,134 @@
 #define PRECISION_S 0
 #define PRECISION_D 1
 
-#define DECLARE_UNPRIVILEGED_LOAD_FUNCTION(type, insn)			\
-static inline type load_##type(const type *addr)			\
-{									\
-	type val;							\
-	asm (#insn " %0, %1"						\
-	: "=&r" (val) : "m" (*addr));					\
-	return val;							\
+#ifdef CONFIG_FPU
+
+#define FP_GET_RD(insn)		(insn >> 7 & 0x1F)
+
+extern void put_f32_reg(unsigned long fp_reg, unsigned long value);
+
+static int set_f32_rd(unsigned long insn, struct pt_regs *regs,
+		      unsigned long val)
+{
+	unsigned long fp_reg = FP_GET_RD(insn);
+
+	put_f32_reg(fp_reg, val);
+	regs->status |= SR_FS_DIRTY;
+
+	return 0;
 }
 
-#define DECLARE_UNPRIVILEGED_STORE_FUNCTION(type, insn)			\
-static inline void store_##type(type *addr, type val)			\
-{									\
-	asm volatile (#insn " %0, %1\n"					\
-	: : "r" (val), "m" (*addr));					\
-}
+extern void put_f64_reg(unsigned long fp_reg, unsigned long value);
 
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(u8, lbu)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(u16, lhu)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(s8, lb)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(s16, lh)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(s32, lw)
-DECLARE_UNPRIVILEGED_STORE_FUNCTION(u8, sb)
-DECLARE_UNPRIVILEGED_STORE_FUNCTION(u16, sh)
-DECLARE_UNPRIVILEGED_STORE_FUNCTION(u32, sw)
-#if defined(CONFIG_64BIT)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(u32, lwu)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(u64, ld)
-DECLARE_UNPRIVILEGED_STORE_FUNCTION(u64, sd)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(ulong, ld)
+static int set_f64_rd(unsigned long insn, struct pt_regs *regs, u64 val)
+{
+	unsigned long fp_reg = FP_GET_RD(insn);
+	unsigned long value;
+
+#if __riscv_xlen == 32
+	value = (unsigned long) &val;
 #else
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(u32, lw)
-DECLARE_UNPRIVILEGED_LOAD_FUNCTION(ulong, lw)
+	value = val;
+#endif
+	put_f64_reg(fp_reg, value);
+	regs->status |= SR_FS_DIRTY;
 
-static inline u64 load_u64(const u64 *addr)
-{
-	return load_u32((u32 *)addr)
-		+ ((u64)load_u32((u32 *)addr + 1) << 32);
+	return 0;
 }
 
-static inline void store_u64(u64 *addr, u64 val)
+#if __riscv_xlen == 32
+extern void get_f64_reg(unsigned long fp_reg, u64 *value);
+
+static u64 get_f64_rs(unsigned long insn, u8 fp_reg_offset,
+		      struct pt_regs *regs)
 {
-	store_u32((u32 *)addr, val);
-	store_u32((u32 *)addr + 1, val >> 32);
+	unsigned long fp_reg = (insn >> fp_reg_offset) & 0x1F;
+	u64 val;
+
+	get_f64_reg(fp_reg, &val);
+	regs->status |= SR_FS_DIRTY;
+
+	return val;
 }
+#else
+
+extern unsigned long get_f64_reg(unsigned long fp_reg);
+
+static unsigned long get_f64_rs(unsigned long insn, u8 fp_reg_offset,
+				struct pt_regs *regs)
+{
+	unsigned long fp_reg = (insn >> fp_reg_offset) & 0x1F;
+	unsigned long val;
+
+	val = get_f64_reg(fp_reg);
+	regs->status |= SR_FS_DIRTY;
+
+	return val;
+}
+
 #endif
 
-static inline ulong get_insn(ulong mepc)
+extern unsigned long get_f32_reg(unsigned long fp_reg);
+
+static unsigned long get_f32_rs(unsigned long insn, u8 fp_reg_offset,
+				struct pt_regs *regs)
+{
+	unsigned long fp_reg = (insn >> fp_reg_offset) & 0x1F;
+	unsigned long val;
+
+	val = get_f32_reg(fp_reg);
+	regs->status |= SR_FS_DIRTY;
+
+	return val;
+}
+
+#else /* CONFIG_FPU */
+static void set_f32_rd(unsigned long insn, struct pt_regs *regs,
+		       unsigned long val) {}
+
+static void set_f64_rd(unsigned long insn, struct pt_regs *regs, u64 val) {}
+
+static unsigned long get_f64_rs(unsigned long insn, u8 fp_reg_offset,
+				struct pt_regs *regs)
+{
+	return 0;
+}
+
+static unsigned long get_f32_rs(unsigned long insn, u8 fp_reg_offset,
+				struct pt_regs *regs)
+{
+	return 0;
+}
+
+#endif
+
+#define GET_F64_RS2(insn, regs) (get_f64_rs(insn, 20, regs))
+#define GET_F64_RS2C(insn, regs) (get_f64_rs(insn, 2, regs))
+#define GET_F64_RS2S(insn, regs) (get_f64_rs(RVC_RS2S(insn), 0, regs))
+
+#define GET_F32_RS2(insn, regs) (get_f32_rs(insn, 20, regs))
+#define GET_F32_RS2C(insn, regs) (get_f32_rs(insn, 2, regs))
+#define GET_F32_RS2S(insn, regs) (get_f32_rs(RVC_RS2S(insn), 0, regs))
+
+#ifdef CONFIG_RISCV_M_MODE
+static inline int load_u8(struct pt_regs *regs, const u8 *addr, u8 *r_val)
+{
+	u8 val;
+
+	asm volatile("lbu %0, %1" : "=&r" (val) : "m" (*addr));
+	*r_val = val;
+
+	return 0;
+}
+
+static inline int store_u8(struct pt_regs *regs, u8 *addr, u8 val)
+{
+	asm volatile ("sb %0, %1\n" : : "r" (val), "m" (*addr));
+
+	return 0;
+}
+
+static inline int get_insn(struct pt_regs *regs, ulong mepc, ulong *r_insn)
 {
 	register ulong __mepc asm ("a2") = mepc;
 	ulong val, rvc_mask = 3, tmp;
@@ -226,8 +311,86 @@ static inline ulong get_insn(ulong mepc)
 	: [addr] "r" (__mepc), [rvc_mask] "r" (rvc_mask),
 	  [xlen_minus_16] "i" (XLEN_MINUS_16));
 
-	return val;
+	*r_insn = val;
+
+	return 0;
 }
+#else
+static inline int load_u8(struct pt_regs *regs, const u8 *addr, u8 *r_val)
+{
+	if (user_mode(regs)) {
+		return __get_user(*r_val, addr);
+	} else {
+		*r_val = *addr;
+		return 0;
+	}
+}
+
+static inline int store_u8(struct pt_regs *regs, u8 *addr, u8 val)
+{
+	if (user_mode(regs)) {
+		return __put_user(val, addr);
+	} else {
+		*addr = val;
+		return 0;
+	}
+}
+
+#define __read_insn(regs, insn, insn_addr)		\
+({							\
+	int __ret;					\
+							\
+	if (user_mode(regs)) {				\
+		__ret = __get_user(insn, insn_addr);	\
+	} else {					\
+		insn = *insn_addr;			\
+		__ret = 0;				\
+	}						\
+							\
+	__ret;						\
+})
+
+static inline int get_insn(struct pt_regs *regs, ulong epc, ulong *r_insn)
+{
+	ulong insn = 0;
+
+	if (epc & 0x2) {
+		ulong tmp = 0;
+		u16 __user *insn_addr = (u16 __user *)epc;
+
+		if (__read_insn(regs, insn, insn_addr))
+			return -EFAULT;
+		/* __get_user() uses regular "lw" which sign extend the loaded
+		 * value make sure to clear higher order bits in case we "or" it
+		 * below with the upper 16 bits half.
+		 */
+		insn &= GENMASK(15, 0);
+		if ((insn & __INSN_LENGTH_MASK) != __INSN_LENGTH_32) {
+			*r_insn = insn;
+			return 0;
+		}
+		insn_addr++;
+		if (__read_insn(regs, tmp, insn_addr))
+			return -EFAULT;
+		*r_insn = (tmp << 16) | insn;
+
+		return 0;
+	} else {
+		u32 __user *insn_addr = (u32 __user *)epc;
+
+		if (__read_insn(regs, insn, insn_addr))
+			return -EFAULT;
+		if ((insn & __INSN_LENGTH_MASK) == __INSN_LENGTH_32) {
+			*r_insn = insn;
+			return 0;
+		}
+		insn &= GENMASK(15, 0);
+		*r_insn = insn;
+
+		return 0;
+	}
+}
+#endif
 
 union reg_data {
 	u8 data_bytes[8];
@@ -235,13 +398,31 @@ union reg_data {
 	u64 data_u64;
 };
 
+static bool unaligned_ctl __read_mostly;
+
+/* sysctl hooks */
+int unaligned_enabled __read_mostly = 1;	/* Enabled by default */
+
 int handle_misaligned_load(struct pt_regs *regs)
 {
 	union reg_data val;
 	unsigned long epc = regs->epc;
-	unsigned long insn = get_insn(epc);
-	unsigned long addr = csr_read(mtval);
+	unsigned long insn;
+	unsigned long addr = regs->badaddr;
 	int i, fp = 0, shift = 0, len = 0;
+
+	perf_sw_event(PERF_COUNT_SW_ALIGNMENT_FAULTS, 1, regs, addr);
+
+	*this_cpu_ptr(&misaligned_access_speed) = RISCV_HWPROBE_MISALIGNED_EMULATED;
+
+	if (!unaligned_enabled)
+		return -1;
+
+	if (user_mode(regs) && (current->thread.align_ctl & PR_UNALIGN_SIGBUS))
+		return -1;
+
+	if (get_insn(regs, epc, &insn))
+		return -1;
 
 	regs->epc = 0;
 
@@ -305,13 +486,21 @@ int handle_misaligned_load(struct pt_regs *regs)
 		return -1;
 	}
 
-	val.data_u64 = 0;
-	for (i = 0; i < len; i++)
-		val.data_bytes[i] = load_u8((void *)(addr + i));
+	if (!IS_ENABLED(CONFIG_FPU) && fp)
+		return -EOPNOTSUPP;
 
-	if (fp)
-		return -1;
-	SET_RD(insn, regs, val.data_ulong << shift >> shift);
+	val.data_u64 = 0;
+	for (i = 0; i < len; i++) {
+		if (load_u8(regs, (void *)(addr + i), &val.data_bytes[i]))
+			return -1;
+	}
+
+	if (!fp)
+		SET_RD(insn, regs, val.data_ulong << shift >> shift);
+	else if (len == 8)
+		set_f64_rd(insn, regs, val.data_u64);
+	else
+		set_f32_rd(insn, regs, val.data_ulong);
 
 	regs->epc = epc + INSN_LEN(insn);
 
@@ -322,9 +511,20 @@ int handle_misaligned_store(struct pt_regs *regs)
 {
 	union reg_data val;
 	unsigned long epc = regs->epc;
-	unsigned long insn = get_insn(epc);
-	unsigned long addr = csr_read(mtval);
-	int i, len = 0;
+	unsigned long insn;
+	unsigned long addr = regs->badaddr;
+	int i, len = 0, fp = 0;
+
+	perf_sw_event(PERF_COUNT_SW_ALIGNMENT_FAULTS, 1, regs, addr);
+
+	if (!unaligned_enabled)
+		return -1;
+
+	if (user_mode(regs) && (current->thread.align_ctl & PR_UNALIGN_SIGBUS))
+		return -1;
+
+	if (get_insn(regs, epc, &insn))
+		return -1;
 
 	regs->epc = 0;
 
@@ -336,6 +536,14 @@ int handle_misaligned_store(struct pt_regs *regs)
 	} else if ((insn & INSN_MASK_SD) == INSN_MATCH_SD) {
 		len = 8;
 #endif
+	} else if ((insn & INSN_MASK_FSD) == INSN_MATCH_FSD) {
+		fp = 1;
+		len = 8;
+		val.data_u64 = GET_F64_RS2(insn, regs);
+	} else if ((insn & INSN_MASK_FSW) == INSN_MATCH_FSW) {
+		fp = 1;
+		len = 4;
+		val.data_ulong = GET_F32_RS2(insn, regs);
 	} else if ((insn & INSN_MASK_SH) == INSN_MATCH_SH) {
 		len = 2;
 #if defined(CONFIG_64BIT)
@@ -354,15 +562,88 @@ int handle_misaligned_store(struct pt_regs *regs)
 		   ((insn >> SH_RD) & 0x1f)) {
 		len = 4;
 		val.data_ulong = GET_RS2C(insn, regs);
+	} else if ((insn & INSN_MASK_C_FSD) == INSN_MATCH_C_FSD) {
+		fp = 1;
+		len = 8;
+		val.data_u64 = GET_F64_RS2S(insn, regs);
+	} else if ((insn & INSN_MASK_C_FSDSP) == INSN_MATCH_C_FSDSP) {
+		fp = 1;
+		len = 8;
+		val.data_u64 = GET_F64_RS2C(insn, regs);
+#if !defined(CONFIG_64BIT)
+	} else if ((insn & INSN_MASK_C_FSW) == INSN_MATCH_C_FSW) {
+		fp = 1;
+		len = 4;
+		val.data_ulong = GET_F32_RS2S(insn, regs);
+	} else if ((insn & INSN_MASK_C_FSWSP) == INSN_MATCH_C_FSWSP) {
+		fp = 1;
+		len = 4;
+		val.data_ulong = GET_F32_RS2C(insn, regs);
+#endif
 	} else {
 		regs->epc = epc;
 		return -1;
 	}
 
-	for (i = 0; i < len; i++)
-		store_u8((void *)(addr + i), val.data_bytes[i]);
+	if (!IS_ENABLED(CONFIG_FPU) && fp)
+		return -EOPNOTSUPP;
+
+	for (i = 0; i < len; i++) {
+		if (store_u8(regs, (void *)(addr + i), val.data_bytes[i]))
+			return -1;
+	}
 
 	regs->epc = epc + INSN_LEN(insn);
 
 	return 0;
+}
+
+bool check_unaligned_access_emulated(int cpu)
+{
+	long *mas_ptr = per_cpu_ptr(&misaligned_access_speed, cpu);
+	unsigned long tmp_var, tmp_val;
+	bool misaligned_emu_detected;
+
+	*mas_ptr = RISCV_HWPROBE_MISALIGNED_UNKNOWN;
+
+	__asm__ __volatile__ (
+		"       "REG_L" %[tmp], 1(%[ptr])\n"
+		: [tmp] "=r" (tmp_val) : [ptr] "r" (&tmp_var) : "memory");
+
+	misaligned_emu_detected = (*mas_ptr == RISCV_HWPROBE_MISALIGNED_EMULATED);
+	/*
+	 * If unaligned_ctl is already set, this means that we detected that all
+	 * CPUS uses emulated misaligned access at boot time. If that changed
+	 * when hotplugging the new cpu, this is something we don't handle.
+	 */
+	if (unlikely(unaligned_ctl && !misaligned_emu_detected)) {
+		pr_crit("CPU misaligned accesses non homogeneous (expected all emulated)\n");
+		while (true)
+			cpu_relax();
+	}
+
+	return misaligned_emu_detected;
+}
+
+void __init unaligned_emulation_finish(void)
+{
+	int cpu;
+
+	/*
+	 * We can only support PR_UNALIGN controls if all CPUs have misaligned
+	 * accesses emulated since tasks requesting such control can run on any
+	 * CPU.
+	 */
+	for_each_present_cpu(cpu) {
+		if (per_cpu(misaligned_access_speed, cpu) !=
+					RISCV_HWPROBE_MISALIGNED_EMULATED) {
+			return;
+		}
+	}
+	unaligned_ctl = true;
+}
+
+bool unaligned_ctl_available(void)
+{
+	return unaligned_ctl;
 }


### PR DESCRIPTION
Pull request for series with
subject: scripts/gdb: add lx_current support for riscv
version: 6
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=796965
