### PR TITLE
dt-bindings: riscv: Document cbop-block-size

### DIFF
--- a/Documentation/devicetree/bindings/riscv/cpus.yaml
+++ b/Documentation/devicetree/bindings/riscv/cpus.yaml
@@ -79,6 +79,11 @@ properties:
     description:
       The blocksize in bytes for the Zicbom cache operations.
 
+  riscv,cbop-block-size:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description:
+      The blocksize in bytes for the Zicbop cache operations.
+
   riscv,cboz-block-size:
     $ref: /schemas/types.yaml#/definitions/uint32
     description:


### PR DESCRIPTION
Pull request for series with
subject: dt-bindings: riscv: Document cbop-block-size
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=797397
