### PR TITLE
RISC-V: Remove duplicated include in smpboot.c

### DIFF
--- a/arch/riscv/kernel/smpboot.c
+++ b/arch/riscv/kernel/smpboot.c
@@ -28,7 +28,6 @@
 
 #include <asm/cpufeature.h>
 #include <asm/cpu_ops.h>
-#include <asm/cpufeature.h>
 #include <asm/irq.h>
 #include <asm/mmu_context.h>
 #include <asm/numa.h>


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: Remove duplicated include in smpboot.c
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=797743
