### PR TITLE
RISC-V: hwprobe: Always use u64 for extension bits

### DIFF
--- a/arch/riscv/kernel/sys_riscv.c
+++ b/arch/riscv/kernel/sys_riscv.c
@@ -169,7 +169,7 @@ static void hwprobe_isa_ext0(struct riscv_hwprobe *pair,
 	pair->value &= ~missing;
 }
 
-static bool hwprobe_ext0_has(const struct cpumask *cpus, unsigned long ext)
+static bool hwprobe_ext0_has(const struct cpumask *cpus, u64 ext)
 {
 	struct riscv_hwprobe pair;
 


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: hwprobe: Always use u64 for extension bits
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=798180
