### PR TITLE
gpio: sifive: remove unneeded call to platform_set_drvdata()

### DIFF
--- a/drivers/gpio/gpio-sifive.c
+++ b/drivers/gpio/gpio-sifive.c
@@ -250,7 +250,6 @@ static int sifive_gpio_probe(struct platform_device *pdev)
 	girq->handler = handle_bad_irq;
 	girq->default_type = IRQ_TYPE_NONE;
 
-	platform_set_drvdata(pdev, chip);
 	return gpiochip_add_data(&chip->gc, chip);
 }
 


### PR DESCRIPTION
Pull request for series with
subject: gpio: sifive: remove unneeded call to platform_set_drvdata()
version: 2
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=800540
