### PR TITLE
riscv: compat_vdso: install compat_vdso.so.dbg to /lib/modules/*/vdso/

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -146,7 +146,7 @@ endif
 endif
 
 vdso-install-y			+= arch/riscv/kernel/vdso/vdso.so.dbg
-vdso-install-$(CONFIG_COMPAT)	+= arch/riscv/kernel/compat_vdso/compat_vdso.so.dbg:../compat_vdso/compat_vdso.so
+vdso-install-$(CONFIG_COMPAT)	+= arch/riscv/kernel/compat_vdso/compat_vdso.so.dbg
 
 ifneq ($(CONFIG_XIP_KERNEL),y)
 ifeq ($(CONFIG_RISCV_M_MODE)$(CONFIG_ARCH_CANAAN),yy)


### PR DESCRIPTION
Pull request for series with
subject: riscv: compat_vdso: install compat_vdso.so.dbg to /lib/modules/*/vdso/
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=801935
