### PR TITLE
riscv: add dependency among Image(.gz), loader(.bin), and vmlinuz.efi

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -163,6 +163,8 @@ BOOT_TARGETS := Image Image.gz loader loader.bin xipImage vmlinuz.efi
 
 all:	$(notdir $(KBUILD_IMAGE))
 
+loader.bin: loader
+Image.gz loader vmlinuz.efi: Image
 $(BOOT_TARGETS): vmlinux
 	$(Q)$(MAKE) $(build)=$(boot) $(boot)/$@
 	@$(kecho) '  Kernel: $(boot)/$@ is ready'


### PR DESCRIPTION
Pull request for series with
subject: riscv: add dependency among Image(.gz), loader(.bin), and vmlinuz.efi
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=802241
