### PR TITLE
riscv: errata: andes: Probe IOCP during boot stage

### DIFF
--- a/arch/riscv/errata/andes/errata.c
+++ b/arch/riscv/errata/andes/errata.c
@@ -60,7 +60,8 @@ void __init_or_module andes_errata_patch_func(struct alt_entry *begin, struct al
 					      unsigned long archid, unsigned long impid,
 					      unsigned int stage)
 {
-	errata_probe_iocp(stage, archid, impid);
+	if (stage == RISCV_ALTERNATIVES_BOOT)
+		errata_probe_iocp(stage, archid, impid);
 
 	/* we have nothing to patch here ATM so just return back */
 }


### PR DESCRIPTION
Pull request for series with
subject: riscv: errata: andes: Probe IOCP during boot stage
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=802987
