### PR TITLE
riscv: Fix SMP when shadow call stacks are enabled

### DIFF
--- a/arch/riscv/kernel/head.S
+++ b/arch/riscv/kernel/head.S
@@ -154,7 +154,6 @@ secondary_start_sbi:
 	XIP_FIXUP_OFFSET a3
 	add a3, a3, a1
 	REG_L sp, (a3)
-	scs_load_current
 
 .Lsecondary_start_common:
 
@@ -165,6 +164,7 @@ secondary_start_sbi:
 	call relocate_enable_mmu
 #endif
 	call .Lsetup_trap_vector
+	scs_load_current
 	tail smp_callin
 #endif /* CONFIG_SMP */
 


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix SMP when shadow call stacks are enabled
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=803005
