### PR TITLE
riscv: declare overflow_stack as exported from traps.c

### DIFF
--- a/arch/riscv/include/asm/stacktrace.h
+++ b/arch/riscv/include/asm/stacktrace.h
@@ -21,4 +21,9 @@ static inline bool on_thread_stack(void)
 	return !(((unsigned long)(current->stack) ^ current_stack_pointer) & ~(THREAD_SIZE - 1));
 }
 
+
+#ifdef CONFIG_VMAP_STACK
+DECLARE_PER_CPU(unsigned long [OVERFLOW_STACK_SIZE/sizeof(long)], overflow_stack);
+#endif /* CONFIG_VMAP_STACK */
+
 #endif /* _ASM_RISCV_STACKTRACE_H */


### PR DESCRIPTION
Pull request for series with
subject: riscv: declare overflow_stack as exported from traps.c
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=803720
