### PR TITLE
riscv, kexec: fix the ifdeffery for AFLAGS_kexec_relocate.o

### DIFF
--- a/arch/riscv/kernel/Makefile
+++ b/arch/riscv/kernel/Makefile
@@ -11,7 +11,7 @@ endif
 CFLAGS_syscall_table.o	+= $(call cc-option,-Wno-override-init,)
 CFLAGS_compat_syscall_table.o += $(call cc-option,-Wno-override-init,)
 
-ifdef CONFIG_KEXEC
+ifdef CONFIG_KEXEC_CORE
 AFLAGS_kexec_relocate.o := -mcmodel=medany $(call cc-option,-mno-relax)
 endif
 


### PR DESCRIPTION
Pull request for series with
subject: riscv, kexec: fix the ifdeffery for AFLAGS_kexec_relocate.o
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=805889
