### PR TITLE
drivers: perf: constify the ctl_table argument of the riscv user access handler

### DIFF
--- a/drivers/perf/riscv_pmu_sbi.c
+++ b/drivers/perf/riscv_pmu_sbi.c
@@ -986,7 +986,7 @@ static void riscv_pmu_update_counter_access(void *info)
 		csr_write(CSR_SCOUNTEREN, 0x2);
 }
 
-static int riscv_pmu_proc_user_access_handler(struct ctl_table *table,
+static int riscv_pmu_proc_user_access_handler(const struct ctl_table *table,
 					      int write, void *buffer,
 					      size_t *lenp, loff_t *ppos)
 {


### PR DESCRIPTION
Pull request for series with
subject: drivers: perf: constify the ctl_table argument of the riscv user access handler
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=807323
