### PR TITLE
riscv: Fix wrong usage of lm_alias() when splitting a huge linear mapping

### DIFF
--- a/arch/riscv/mm/pageattr.c
+++ b/arch/riscv/mm/pageattr.c
@@ -305,8 +305,13 @@ static int __set_memory(unsigned long addr, int numpages, pgprot_t set_mask,
 				goto unlock;
 		}
 	} else if (is_kernel_mapping(start) || is_linear_mapping(start)) {
-		lm_start = (unsigned long)lm_alias(start);
-		lm_end = (unsigned long)lm_alias(end);
+		if (is_kernel_mapping(start)) {
+			lm_start = (unsigned long)lm_alias(start);
+			lm_end = (unsigned long)lm_alias(end);
+		} else {
+			lm_start = start;
+			lm_end = end;
+		}
 
 		ret = split_linear_mapping(lm_start, lm_end);
 		if (ret)


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix wrong usage of lm_alias() when splitting a huge linear mapping
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=808807
