### PR TITLE
arch/riscv/kernel/sys_riscv.c: removed asm-generic

### DIFF
--- a/arch/riscv/kernel/sys_riscv.c
+++ b/arch/riscv/kernel/sys_riscv.c
@@ -14,7 +14,6 @@
 #include <asm/switch_to.h>
 #include <asm/uaccess.h>
 #include <asm/unistd.h>
-#include <asm-generic/mman-common.h>
 #include <vdso/vsyscall.h>
 
 static long riscv_sys_mmap(unsigned long addr, unsigned long len,


### PR DESCRIPTION
Pull request for series with
subject: arch/riscv/kernel/sys_riscv.c: removed asm-generic
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=808963
