### PR TITLE
Fix WX mappings in the linear mapping after module unloading

### DIFF
--- a/arch/riscv/kernel/module.c
+++ b/arch/riscv/kernel/module.c
@@ -840,7 +840,8 @@ void *module_alloc(unsigned long size)
 {
 	return __vmalloc_node_range(size, 1, MODULES_VADDR,
 				    MODULES_END, GFP_KERNEL,
-				    PAGE_KERNEL, 0, NUMA_NO_NODE,
+				    PAGE_KERNEL, VM_FLUSH_RESET_PERMS,
+				    NUMA_NO_NODE,
 				    __builtin_return_address(0));
 }
 #endif

--- a/arch/riscv/mm/pageattr.c
+++ b/arch/riscv/mm/pageattr.c
@@ -378,7 +378,7 @@ int set_direct_map_invalid_noflush(struct page *page)
 int set_direct_map_default_noflush(struct page *page)
 {
 	return __set_memory((unsigned long)page_address(page), 1,
-			    PAGE_KERNEL, __pgprot(0));
+			    PAGE_KERNEL, __pgprot(_PAGE_EXEC));
 }
 
 #ifdef CONFIG_DEBUG_PAGEALLOC


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix module_alloc() that did not reset the linear mapping permissions
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=809679
