### PR TITLE
riscv: put va_kernel_xip_pa_offset into CONFIG_XIP_KERNEL

### DIFF
--- a/arch/riscv/include/asm/page.h
+++ b/arch/riscv/include/asm/page.h
@@ -113,8 +113,8 @@ struct kernel_mapping {
 	unsigned long va_pa_offset;
 	/* Offset between kernel mapping virtual address and kernel load address */
 	unsigned long va_kernel_pa_offset;
-	unsigned long va_kernel_xip_pa_offset;
 #ifdef CONFIG_XIP_KERNEL
+	unsigned long va_kernel_xip_pa_offset;
 	uintptr_t xiprom;
 	uintptr_t xiprom_sz;
 #endif
@@ -134,12 +134,25 @@ extern phys_addr_t phys_ram_base;
 #else
 void *linear_mapping_pa_to_va(unsigned long x);
 #endif
-#define kernel_mapping_pa_to_va(y)	({					\
-	unsigned long _y = (unsigned long)(y);					\
-	(IS_ENABLED(CONFIG_XIP_KERNEL) && _y < phys_ram_base) ?			\
-		(void *)(_y + kernel_map.va_kernel_xip_pa_offset) :		\
-		(void *)(_y + kernel_map.va_kernel_pa_offset + XIP_OFFSET);	\
-	})
+
+#ifdef CONFIG_XIP_KERNEL
+#define kernel_mapping_pa_to_va(y)							\
+	(((unsigned long)(y) < phys_ram_base) ?						\
+		(void *)((unsigned long)(y) + kernel_map.va_kernel_xip_pa_offset) :	\
+		(void *)((unsigned long)(y) + kernel_map.va_kernel_pa_offset + XIP_OFFSET))
+
+#define kernel_mapping_va_to_pa(y)						\
+	(((unsigned long)(y) < kernel_map.virt_addr + XIP_OFFSET) ?		\
+		((unsigned long)(y) - kernel_map.va_kernel_xip_pa_offset) :	\
+		((unsigned long)(y) - kernel_map.va_kernel_pa_offset - XIP_OFFSET))
+#else
+#define kernel_mapping_pa_to_va(y)						\
+	((void *)((unsigned long)(y) + kernel_map.va_kernel_pa_offset + XIP_OFFSET))
+
+#define kernel_mapping_va_to_pa(y)						\
+	((unsigned long)(y) - kernel_map.va_kernel_pa_offset - XIP_OFFSET)
+#endif
+
 #define __pa_to_va_nodebug(x)		linear_mapping_pa_to_va(x)
 
 #ifndef CONFIG_DEBUG_VIRTUAL
@@ -147,12 +160,6 @@ void *linear_mapping_pa_to_va(unsigned long x);
 #else
 phys_addr_t linear_mapping_va_to_pa(unsigned long x);
 #endif
-#define kernel_mapping_va_to_pa(y) ({						\
-	unsigned long _y = (unsigned long)(y);					\
-	(IS_ENABLED(CONFIG_XIP_KERNEL) && _y < kernel_map.virt_addr + XIP_OFFSET) ? \
-		(_y - kernel_map.va_kernel_xip_pa_offset) :			\
-		(_y - kernel_map.va_kernel_pa_offset - XIP_OFFSET);		\
-	})
 
 #define __va_to_pa_nodebug(x)	({						\
 	unsigned long _x = x;							\


### PR DESCRIPTION
Pull request for series with
subject: riscv: put va_kernel_xip_pa_offset into CONFIG_XIP_KERNEL
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=811763
