### PR TITLE
irqchip/sifive-plic: One function call less in __plic_init() after error detection

### DIFF
--- a/drivers/irqchip/irq-sifive-plic.c
+++ b/drivers/irqchip/irq-sifive-plic.c
@@ -437,7 +437,7 @@ static int __init __plic_init(struct device_node *node,
 
 	priv->prio_save = bitmap_alloc(nr_irqs, GFP_KERNEL);
 	if (!priv->prio_save)
-		goto out_free_priority_reg;
+		goto out_iounmap;
 
 	nr_contexts = of_irq_count(node);
 	if (WARN_ON(!nr_contexts))


### PR DESCRIPTION
Pull request for series with
subject: irqchip/sifive-plic: One function call less in __plic_init() after error detection
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=812946
