### PR TITLE
riscv: Use kcalloc() instead of kzalloc()

### DIFF
--- a/arch/riscv/kernel/cpufeature.c
+++ b/arch/riscv/kernel/cpufeature.c
@@ -901,8 +901,7 @@ static int check_unaligned_access_all_cpus(void)
 {
 	unsigned int cpu;
 	unsigned int cpu_count = num_possible_cpus();
-	struct page **bufs = kzalloc(cpu_count * sizeof(struct page *),
-				     GFP_KERNEL);
+	struct page **bufs = kcalloc(cpu_count, sizeof(*bufs), GFP_KERNEL);
 
 	if (!bufs) {
 		pr_warn("Allocation failure, not measuring misaligned performance\n");


### PR DESCRIPTION
Pull request for series with
subject: riscv: Use kcalloc() instead of kzalloc()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=818296
