### PR TITLE
soc: microchip: Fix POLARFIRE_SOC_SYS_CTRL input prompt

### DIFF
--- a/drivers/soc/microchip/Kconfig
+++ b/drivers/soc/microchip/Kconfig
@@ -1,5 +1,5 @@
 config POLARFIRE_SOC_SYS_CTRL
-	tristate "POLARFIRE_SOC_SYS_CTRL"
+	tristate "Microchip PolarFire SoC (MPFS) system controller support"
 	depends on POLARFIRE_SOC_MAILBOX
 	depends on MTD
 	help


### PR DESCRIPTION
Pull request for series with
subject: soc: microchip: Fix POLARFIRE_SOC_SYS_CTRL input prompt
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=818659
