### PR TITLE
arch/arm/mm: fix major fault accounting when retrying under per-VMA lock

### DIFF
--- a/arch/arm/mm/fault.c
+++ b/arch/arm/mm/fault.c
@@ -298,6 +298,8 @@ do_page_fault(unsigned long addr, unsigned int fsr, struct pt_regs *regs)
 		goto done;
 	}
 	count_vm_vma_lock_event(VMA_LOCK_RETRY);
+	if (fault & VM_FAULT_MAJOR)
+		flags |= FAULT_FLAG_TRIED;
 
 	/* Quick path to respond to signals */
 	if (fault_signal_pending(fault, regs)) {


### PR DESCRIPTION
Pull request for series with
subject: arch/arm/mm: fix major fault accounting when retrying under per-VMA lock
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=818967
