### PR TITLE
riscv: Fix wrong size passed to local_flush_tlb_range_asid()

### DIFF
--- a/arch/riscv/mm/tlbflush.c
+++ b/arch/riscv/mm/tlbflush.c
@@ -68,7 +68,7 @@ static inline void local_flush_tlb_range_asid(unsigned long start,
 
 void local_flush_tlb_kernel_range(unsigned long start, unsigned long end)
 {
-	local_flush_tlb_range_asid(start, end, PAGE_SIZE, FLUSH_TLB_NO_ASID);
+	local_flush_tlb_range_asid(start, end - start, PAGE_SIZE, FLUSH_TLB_NO_ASID);
 }
 
 static void __ipi_flush_tlb_all(void *info)


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix wrong size passed to local_flush_tlb_range_asid()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=819115
