### PR TITLE
RISC-V: add uniprocessor flush_tlb_range() support

### DIFF
--- a/arch/riscv/mm/Makefile
+++ b/arch/riscv/mm/Makefile
@@ -19,7 +19,7 @@ obj-y += context.o
 obj-y += pmem.o
 
 ifeq ($(CONFIG_MMU),y)
-obj-$(CONFIG_SMP) += tlbflush.o
+obj-y += tlbflush.o
 endif
 obj-$(CONFIG_HUGETLB_PAGE) += hugetlbpage.o
 obj-$(CONFIG_PTDUMP_CORE) += ptdump.o


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: add uniprocessor flush_tlb_range() support
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=819718
