### PR TITLE
clocksource: timer-riscv: Clear timer interrupt on timer initialization

### DIFF
--- a/drivers/clocksource/timer-riscv.c
+++ b/drivers/clocksource/timer-riscv.c
@@ -116,6 +116,9 @@ static int riscv_timer_starting_cpu(unsigned int cpu)
 		ce->rating = 450;
 	clockevents_config_and_register(ce, riscv_timebase, 100, ULONG_MAX);
 
+	/* Clear timer interrupt */
+	riscv_clock_event_stop();
+
 	enable_percpu_irq(riscv_clock_event_irq,
 			  irq_get_trigger_type(riscv_clock_event_irq));
 	return 0;


### PR DESCRIPTION
Pull request for series with
subject: clocksource: timer-riscv: Clear timer interrupt on timer initialization
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=819970
