### PR TITLE
RISC-V: fix check for zvkb with tip-of-tree clang

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -592,7 +592,7 @@ config TOOLCHAIN_HAS_ZBB
 # extensions, including Zvk*, Zvbb, and Zvbc.  LLVM added all of these at once.
 # binutils added all except Zvkb, then added Zvkb.  So we just check for Zvkb.
 config TOOLCHAIN_HAS_VECTOR_CRYPTO
-	def_bool $(as-instr, .option arch$(comma) +zvkb)
+	def_bool $(as-instr, .option arch$(comma) +v$(comma) +zvkb)
 	depends on AS_HAS_OPTION_ARCH
 
 config RISCV_ISA_ZBB


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: fix check for zvkb with tip-of-tree clang
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=820498
