### PR TITLE
cache: ax45mp_cache: Align end size to cache boundary in ax45mp_dma_cache_wback()

### DIFF
--- a/drivers/cache/ax45mp_cache.c
+++ b/drivers/cache/ax45mp_cache.c
@@ -129,8 +129,12 @@ static void ax45mp_dma_cache_wback(phys_addr_t paddr, size_t size)
 	unsigned long line_size;
 	unsigned long flags;
 
+	if (unlikely(start == end))
+		return;
+
 	line_size = ax45mp_priv.ax45mp_cache_line_size;
 	start = start & (~(line_size - 1));
+	end = ((end + line_size - 1) & (~(line_size - 1)));
 	local_irq_save(flags);
 	ax45mp_cpu_dcache_wb_range(start, end);
 	local_irq_restore(flags);


### PR DESCRIPTION
Pull request for series with
subject: cache: ax45mp_cache: Align end size to cache boundary in ax45mp_dma_cache_wback()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=822811
