### PR TITLE
riscv: use KERN_INFO in do_trap

### DIFF
--- a/arch/riscv/kernel/traps.c
+++ b/arch/riscv/kernel/traps.c
@@ -122,7 +122,7 @@ void do_trap(struct pt_regs *regs, int signo, int code, unsigned long addr)
 		print_vma_addr(KERN_CONT " in ", instruction_pointer(regs));
 		pr_cont("\n");
 		__show_regs(regs);
-		dump_instr(KERN_EMERG, regs);
+		dump_instr(KERN_INFO, regs);
 	}
 
 	force_sig_fault(signo, code, (void __user *)addr);


### PR DESCRIPTION
Pull request for series with
subject: riscv: use KERN_INFO in do_trap
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=825528
