### PR TITLE
riscv: dts: sifive: add missing #interrupt-cells to pmic

### DIFF
--- a/arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dts
+++ b/arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dts
@@ -123,6 +123,7 @@
 		interrupt-parent = <&gpio>;
 		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
 		interrupt-controller;
+		#interrupt-cells = <2>;
 
 		onkey {
 			compatible = "dlg,da9063-onkey";


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: sifive: add missing #interrupt-cells to pmic
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=825775
