### PR TITLE
riscv: deprecate CONFIG_MMU=n

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -231,6 +231,7 @@ config ARCH_MMAP_RND_COMPAT_BITS_MAX
 # set if we run in machine mode, cleared if we run in supervisor mode
 config RISCV_M_MODE
 	bool
+	select NOMMU
 	default !MMU
 
 # set if we are running in S-mode and can use SBI calls
@@ -245,6 +246,13 @@ config MMU
 	help
 	  Select if you want MMU-based virtualised addressing space
 	  support by paged memory management. If unsure, say 'Y'.
+
+config NOMMU
+	depends on !MMU
+	bool "NOMMU kernel (DEPRECATED)"
+	help
+	  NOMMU kernel is deprecated and is scheduled for removal by
+	  the beginning of 2027.
 
 config PAGE_OFFSET
 	hex

--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -295,6 +295,10 @@ void __init setup_arch(char **cmdline_p)
 	riscv_set_dma_cache_alignment();
 
 	riscv_user_isa_enable();
+
+#if !defined(CONFIG_MMU)
+	pr_err("RISC-V NOMMU support is deprecated and scheduled for removal by the beginning of 2027\n");
+#endif
 }
 
 bool arch_cpu_is_hotpluggable(int cpu)


### PR DESCRIPTION
Pull request for series with
subject: riscv: deprecate CONFIG_MMU=n
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=829886
