### PR TITLE
riscv: Fix compilation error with FAST_GUP and rv32

### DIFF
--- a/arch/riscv/include/asm/pgtable.h
+++ b/arch/riscv/include/asm/pgtable.h
@@ -439,9 +439,11 @@ static inline pte_t pte_mkhuge(pte_t pte)
 	return pte;
 }
 
+#ifdef CONFIG_RISCV_ISA_SVNAPOT
 #define pte_leaf_size(pte)	(pte_napot(pte) ?				\
 					napot_cont_size(napot_cont_order(pte)) :\
 					PAGE_SIZE)
+#endif
 
 #ifdef CONFIG_NUMA_BALANCING
 /*


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix compilation error with FAST_GUP and rv32
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=831975
