### PR TITLE
drivers/perf: riscv: Disable PERF_SAMPLE_BRANCH_* while not supported

### DIFF
--- a/drivers/perf/riscv_pmu.c
+++ b/drivers/perf/riscv_pmu.c
@@ -313,6 +313,10 @@ static int riscv_pmu_event_init(struct perf_event *event)
 	u64 event_config = 0;
 	uint64_t cmask;
 
+	/* driver does not support branch stack sampling */
+	if (has_branch_stack(event))
+		return -EOPNOTSUPP;
+
 	hwc->flags = 0;
 	mapped_event = rvpmu->event_map(event, &event_config);
 	if (mapped_event < 0) {


### PR DESCRIPTION
Pull request for series with
subject: drivers/perf: riscv: Disable PERF_SAMPLE_BRANCH_* while not supported
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=832589
