### PR TITLE
riscv: dts: starfive: Remove PMIC interrupt info for Visionfive 2 board

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
@@ -238,7 +238,6 @@
 	axp15060: pmic@36 {
 		compatible = "x-powers,axp15060";
 		reg = <0x36>;
-		interrupts = <0>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: starfive: Remove PMIC interrupt info for Visionfive 2 board
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=832631
