### PR TITLE
clocksource: timer-riscv: Clear timer interrupt on timer initialization

### DIFF
--- a/drivers/clocksource/timer-riscv.c
+++ b/drivers/clocksource/timer-riscv.c
@@ -108,6 +108,9 @@ static int riscv_timer_starting_cpu(unsigned int cpu)
 {
 	struct clock_event_device *ce = per_cpu_ptr(&riscv_clock_event, cpu);
 
+	/* Clear timer interrupt */
+	riscv_clock_event_stop();
+
 	ce->cpumask = cpumask_of(cpu);
 	ce->irq = riscv_clock_event_irq;
 	if (riscv_timer_cannot_wake_cpu)


### PR DESCRIPTION
Pull request for series with
subject: clocksource: timer-riscv: Clear timer interrupt on timer initialization
version: 3
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=833065
