### PR TITLE
riscv: hwprobe: do not produce frtace relocation

### DIFF
--- a/arch/riscv/kernel/vdso/Makefile
+++ b/arch/riscv/kernel/vdso/Makefile
@@ -37,6 +37,7 @@ endif
 
 # Disable -pg to prevent insert call site
 CFLAGS_REMOVE_vgettimeofday.o = $(CC_FLAGS_FTRACE) $(CC_FLAGS_SCS)
+CFLAGS_REMOVE_hwprobe.o = $(CC_FLAGS_FTRACE) $(CC_FLAGS_SCS)
 
 # Disable profiling and instrumentation for VDSO code
 GCOV_PROFILE := n


### PR DESCRIPTION
Pull request for series with
subject: riscv: hwprobe: do not produce frtace relocation
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=834887
