### PR TITLE
RISC-V: KVM: Remove second semicolon

### DIFF
--- a/arch/riscv/kvm/vcpu_onereg.c
+++ b/arch/riscv/kvm/vcpu_onereg.c
@@ -928,7 +928,7 @@ static int copy_isa_ext_reg_indices(const struct kvm_vcpu *vcpu,
 
 static inline unsigned long num_isa_ext_regs(const struct kvm_vcpu *vcpu)
 {
-	return copy_isa_ext_reg_indices(vcpu, NULL);;
+	return copy_isa_ext_reg_indices(vcpu, NULL);
 }
 
 static int copy_sbi_ext_reg_indices(struct kvm_vcpu *vcpu, u64 __user *uindices)


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: KVM: Remove second semicolon
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=835551
