### PR TITLE
bpf: verifier: fix NULL pointer dereference in do_misc_fixups()

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -19598,7 +19598,8 @@ static int do_misc_fixups(struct bpf_verifier_env *env)
 	for (i = 0; i < insn_cnt;) {
 		if (insn->code == (BPF_ALU64 | BPF_MOV | BPF_X) && insn->imm) {
 			if ((insn->off == BPF_ADDR_SPACE_CAST && insn->imm == 1) ||
-			    (((struct bpf_map *)env->prog->aux->arena)->map_flags & BPF_F_NO_USER_CONV)) {
+			    (env->prog->aux->arena &&
+			     (((struct bpf_map *)env->prog->aux->arena)->map_flags & BPF_F_NO_USER_CONV))) {
 				/* convert to 32-bit mov that clears upper 32-bit */
 				insn->code = BPF_ALU | BPF_MOV | BPF_X;
 				/* clear off, so it's a normal 'wX = wY' from JIT pov */


### PR DESCRIPTION
Pull request for series with
subject: bpf: verifier: fix NULL pointer dereference in do_misc_fixups()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=837398
