### PR TITLE
Add StarFive JH8100 dwmac support

### DIFF
--- a/Documentation/devicetree/bindings/net/snps,dwmac.yaml
+++ b/Documentation/devicetree/bindings/net/snps,dwmac.yaml
@@ -97,6 +97,7 @@ properties:
         - snps,dwxgmac-2.10
         - starfive,jh7100-dwmac
         - starfive,jh7110-dwmac
+        - starfive,jh8100-dwmac
 
   reg:
     minItems: 1

--- a/Documentation/devicetree/bindings/net/starfive,jh7110-dwmac.yaml
+++ b/Documentation/devicetree/bindings/net/starfive,jh7110-dwmac.yaml
@@ -18,6 +18,7 @@ select:
         enum:
           - starfive,jh7100-dwmac
           - starfive,jh7110-dwmac
+          - starfive,jh8100-dwmac
   required:
     - compatible
 
@@ -28,6 +29,10 @@ properties:
           - const: starfive,jh7100-dwmac
           - const: snps,dwmac
       - items:
+          - const: starfive,jh7110-dwmac
+          - const: snps,dwmac-5.20
+      - items:
+          - const: starfive,jh8100-dwmac
           - const: starfive,jh7110-dwmac
           - const: snps,dwmac-5.20
 
@@ -116,11 +121,25 @@ allOf:
           minItems: 3
           maxItems: 3
 
-        resets:
-          minItems: 2
+      if:
+        properties:
+          compatible:
+            contains:
+              const: starfive,jh8100-dwmac
+      then:
+        properties:
+          resets:
+            maxItems: 1
 
-        reset-names:
-          minItems: 2
+          reset-names:
+            const: stmmaceth
+      else:
+        properties:
+          resets:
+            minItems: 2
+
+          reset-names:
+            minItems: 2
 
 unevaluatedProperties: false
 


### PR DESCRIPTION
Pull request for series with
subject: Add StarFive JH8100 dwmac support
version: 3
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=837765
