### PR TITLE
riscv: mm: still create swiotlb buffer for kmalloc() bouncing if required

### DIFF
--- a/arch/riscv/include/asm/cache.h
+++ b/arch/riscv/include/asm/cache.h
@@ -26,8 +26,8 @@
 
 #ifndef __ASSEMBLY__
 
-#ifdef CONFIG_RISCV_DMA_NONCOHERENT
 extern int dma_cache_alignment;
+#ifdef CONFIG_RISCV_DMA_NONCOHERENT
 #define dma_get_cache_alignment dma_get_cache_alignment
 static inline int dma_get_cache_alignment(void)
 {


### PR DESCRIPTION
Pull request for series with
subject: riscv: mm: still create swiotlb buffer for kmalloc() bouncing if required
version: 3
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=837839
