### PR TITLE
clk: starfive: pll: Fix lower rate of CPUfreq by setting PLL0 rate to 1.5GHz

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
@@ -336,6 +336,11 @@
 	status = "okay";
 };
 
+&pllclk {
+	assigned-clocks = <&pllclk JH7110_PLLCLK_PLL0_OUT>;
+	assigned-clock-rates = <1500000000>;
+};
+
 &qspi {
 	#address-cells = <1>;
 	#size-cells = <0>;


### PR DESCRIPTION
Pull request for series with
subject: clk: starfive: pll: Fix lower rate of CPUfreq by setting PLL0 rate to 1.5GHz
version: 3
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=840524
