### PR TITLE
rust: make mutually exclusive with CFI_CLANG

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1899,6 +1899,7 @@ config RUST
 	bool "Rust support"
 	depends on HAVE_RUST
 	depends on RUST_IS_AVAILABLE
+	depends on !CFI_CLANG
 	depends on !MODVERSIONS
 	depends on !GCC_PLUGINS
 	depends on !RANDSTRUCT


### PR DESCRIPTION
Pull request for series with
subject: rust: make mutually exclusive with CFI_CLANG
version: 3
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=841460
