### PR TITLE
MAINTAINERS: bpf: Add Lehui and Puranjay as riscv64 reviewers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3764,6 +3764,8 @@ X:	arch/riscv/net/bpf_jit_comp64.c
 
 BPF JIT for RISC-V (64-bit)
 M:	Björn Töpel <bjorn@kernel.org>
+R:	Pu Lehui <pulehui@huawei.com>
+R:	Puranjay Mohan <puranjay@kernel.org>
 L:	bpf@vger.kernel.org
 S:	Maintained
 F:	arch/riscv/net/


### PR DESCRIPTION
Pull request for series with
subject: MAINTAINERS: bpf: Add Lehui and Puranjay as riscv64 reviewers
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=841822
