### PR TITLE
Revert "riscv: disable generation of unwind tables"

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -101,9 +101,6 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
 	KBUILD_CFLAGS += -mcmodel=medany
 endif
 
-# Avoid generating .eh_frame sections.
-KBUILD_CFLAGS += -fno-asynchronous-unwind-tables -fno-unwind-tables
-
 # The RISC-V attributes frequently cause compatibility issues and provide no
 # information, so just turn them off.
 KBUILD_CFLAGS += $(call cc-option,-mno-riscv-attribute)


### PR DESCRIPTION
Pull request for series with
subject: Revert "riscv: disable generation of unwind tables"
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=844861
