### PR TITLE
init: fix allocated page overlapping with PTR_ERR

### DIFF
--- a/init/main.c
+++ b/init/main.c
@@ -895,6 +895,7 @@ void start_kernel(void)
 	page_address_init();
 	pr_notice("%s", linux_banner);
 	early_security_init();
+	memblock_reserve(__pa(-PAGE_SIZE), PAGE_SIZE); /* reserve last page for ERR_PTR */
 	setup_arch(&command_line);
 	setup_boot_config();
 	setup_command_line(command_line);


### PR DESCRIPTION
Pull request for series with
subject: init: fix allocated page overlapping with PTR_ERR
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=845745
