### PR TITLE
RISC-V: fix Andes errata build issues

### DIFF
--- a/arch/riscv/errata/andes/errata.c
+++ b/arch/riscv/errata/andes/errata.c
@@ -17,6 +17,7 @@
 #include <asm/processor.h>
 #include <asm/sbi.h>
 #include <asm/vendorid_list.h>
+#include <asm/vendor_extensions.h>
 
 #define ANDES_AX45MP_MARCHID		0x8000000000008a45UL
 #define ANDES_AX45MP_MIMPID		0x500UL


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: fix Andes errata build issues
version: 2
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=853468
