### PR TITLE
Documentation: RISC-V: uabi: Only scalar misaligned loads are supported

### DIFF
--- a/Documentation/arch/riscv/uabi.rst
+++ b/Documentation/arch/riscv/uabi.rst
@@ -65,4 +65,6 @@ the extension, or may have deliberately removed it from the listing.
 Misaligned accesses
 -------------------
 
-Misaligned accesses are supported in userspace, but they may perform poorly.
+Misaligned scalar accesses are supported in userspace, but they may perform
+poorly.  Misaligned vector accesses are only supported if the Zicclsm extension
+is supported.


### PR DESCRIPTION
Pull request for series with
subject: Documentation: RISC-V: uabi: Only scalar misaligned loads are supported
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=855774
