### PR TITLE
RISC-V: io: Don't have a void* PCI_IOBASE

### DIFF
--- a/arch/riscv/include/asm/io.h
+++ b/arch/riscv/include/asm/io.h
@@ -27,7 +27,7 @@
  */
 #ifdef CONFIG_MMU
 #define IO_SPACE_LIMIT		(PCI_IO_SIZE - 1)
-#define PCI_IOBASE		((void __iomem *)PCI_IO_START)
+#define PCI_IOBASE		((u8 __iomem *)PCI_IO_START)
 #endif /* CONFIG_MMU */
 
 /*


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: io: Don't have a void* PCI_IOBASE
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=855968
