### PR TITLE
clocksource: use symbolic error names (%pe) to print logs

### DIFF
--- a/drivers/clocksource/arm_arch_timer.c
+++ b/drivers/clocksource/arm_arch_timer.c
@@ -1273,7 +1273,7 @@ static int __init arch_timer_register(void)
 	}
 
 	if (err) {
-		pr_err("can't register interrupt %d (%d)\n", ppi, err);
+		pr_err("can't register interrupt %d: %pe\n", ppi, ERR_PTR(err));
 		goto out_free;
 	}
 

--- a/drivers/clocksource/arm_global_timer.c
+++ b/drivers/clocksource/arm_global_timer.c
@@ -399,8 +399,8 @@ static int __init global_timer_of_register(struct device_node *np)
 	err = request_percpu_irq(gt_ppi, gt_clockevent_interrupt,
 				 "gt", gt_evt);
 	if (err) {
-		pr_warn("global-timer: can't register interrupt %d (%d)\n",
-			gt_ppi, err);
+		pr_warn("global-timer: can't register interrupt %d: %pe\n",
+			gt_ppi, ERR_PTR(err));
 		goto out_free;
 	}
 

--- a/drivers/clocksource/armv7m_systick.c
+++ b/drivers/clocksource/armv7m_systick.c
@@ -60,7 +60,7 @@ static int __init system_timer_of_register(struct device_node *np)
 	ret = clocksource_mmio_init(base + SYST_CVR, "arm_system_timer", rate,
 			200, 24, clocksource_mmio_readl_down);
 	if (ret) {
-		pr_err("failed to init clocksource (%d)\n", ret);
+		pr_err("failed to init clocksource: %pe\n", ERR_PTR(ret));
 		if (clk)
 			goto out_clk_disable;
 		else
@@ -77,7 +77,7 @@ out_clk_put:
 	clk_put(clk);
 out_unmap:
 	iounmap(base);
-	pr_warn("ARM System timer register failed (%d)\n", ret);
+	pr_warn("ARM System timer register failed: %pe\n", ERR_PTR(ret));
 
 	return ret;
 }

--- a/drivers/clocksource/hyperv_timer.c
+++ b/drivers/clocksource/hyperv_timer.c
@@ -205,7 +205,7 @@ static int hv_setup_stimer0_irq(void)
 	ret = acpi_register_gsi(NULL, HYPERV_STIMER0_VECTOR,
 			ACPI_EDGE_SENSITIVE, ACPI_ACTIVE_HIGH);
 	if (ret < 0) {
-		pr_err("Can't register Hyper-V stimer0 GSI. Error %d", ret);
+		pr_err("Can't register Hyper-V stimer0 GSI. Error: %pe", ERR_PTR(ret));
 		return ret;
 	}
 	stimer0_irq = ret;
@@ -213,8 +213,8 @@ static int hv_setup_stimer0_irq(void)
 	ret = request_percpu_irq(stimer0_irq, hv_stimer0_percpu_isr,
 		"Hyper-V stimer0", &stimer0_evt);
 	if (ret) {
-		pr_err("Can't request Hyper-V stimer0 IRQ %d. Error %d",
-			stimer0_irq, ret);
+		pr_err("Can't request Hyper-V stimer0 IRQ %d. Error: %pe",
+			stimer0_irq, ERR_PTR(ret));
 		acpi_unregister_gsi(stimer0_irq);
 		stimer0_irq = -1;
 	}

--- a/drivers/clocksource/jcore-pit.c
+++ b/drivers/clocksource/jcore-pit.c
@@ -156,7 +156,7 @@ static int __init jcore_pit_init(struct device_node *node)
 				    NSEC_PER_SEC, 400, 32,
 				    jcore_clocksource_read);
 	if (err) {
-		pr_err("Error registering clocksource device: %d\n", err);
+		pr_err("Error registering clocksource device: %pe\n", ERR_PTR(err));
 		return err;
 	}
 
@@ -172,7 +172,7 @@ static int __init jcore_pit_init(struct device_node *node)
 			  IRQF_TIMER | IRQF_PERCPU,
 			  "jcore_pit", jcore_pit_percpu);
 	if (err) {
-		pr_err("pit irq request failed: %d\n", err);
+		pr_err("pit irq request failed: %pe\n", ERR_PTR(err));
 		free_percpu(jcore_pit_percpu);
 		return err;
 	}

--- a/drivers/clocksource/mips-gic-timer.c
+++ b/drivers/clocksource/mips-gic-timer.c
@@ -150,7 +150,7 @@ static int gic_clockevent_init(void)
 
 	ret = setup_percpu_irq(gic_timer_irq, &gic_compare_irqaction);
 	if (ret < 0) {
-		pr_err("IRQ %d setup failed (%d)\n", gic_timer_irq, ret);
+		pr_err("IRQ %d setup failed: %pe\n", gic_timer_irq, ERR_PTR(ret));
 		return ret;
 	}
 

--- a/drivers/clocksource/mps2-timer.c
+++ b/drivers/clocksource/mps2-timer.c
@@ -109,13 +109,13 @@ static int __init mps2_clockevent_init(struct device_node *np)
 		clk = of_clk_get(np, 0);
 		if (IS_ERR(clk)) {
 			ret = PTR_ERR(clk);
-			pr_err("failed to get clock for clockevent: %d\n", ret);
+			pr_err("failed to get clock for clockevent: %pe\n", clk);
 			goto out;
 		}
 
 		ret = clk_prepare_enable(clk);
 		if (ret) {
-			pr_err("failed to enable clock for clockevent: %d\n", ret);
+			pr_err("failed to enable clock for clockevent: %pe\n", ERR_PTR(ret));
 			goto out_clk_put;
 		}
 
@@ -125,14 +125,14 @@ static int __init mps2_clockevent_init(struct device_node *np)
 	base = of_iomap(np, 0);
 	if (!base) {
 		ret = -EADDRNOTAVAIL;
-		pr_err("failed to map register for clockevent: %d\n", ret);
+		pr_err("failed to map register for clockevent: %pe\n", ERR_PTR(ret));
 		goto out_clk_disable;
 	}
 
 	irq = irq_of_parse_and_map(np, 0);
 	if (!irq) {
 		ret = -ENOENT;
-		pr_err("failed to get irq for clockevent: %d\n", ret);
+		pr_err("failed to get irq for clockevent: %pe\n", ERR_PTR(ret));
 		goto out_iounmap;
 	}
 
@@ -159,7 +159,7 @@ static int __init mps2_clockevent_init(struct device_node *np)
 
 	ret = request_irq(irq, mps2_timer_interrupt, IRQF_TIMER, name, ce);
 	if (ret) {
-		pr_err("failed to request irq for clockevent: %d\n", ret);
+		pr_err("failed to request irq for clockevent: %pe\n", ERR_PTR(ret));
 		goto out_kfree;
 	}
 
@@ -193,13 +193,13 @@ static int __init mps2_clocksource_init(struct device_node *np)
 		clk = of_clk_get(np, 0);
 		if (IS_ERR(clk)) {
 			ret = PTR_ERR(clk);
-			pr_err("failed to get clock for clocksource: %d\n", ret);
+			pr_err("failed to get clock for clocksource: %pe\n", clk);
 			goto out;
 		}
 
 		ret = clk_prepare_enable(clk);
 		if (ret) {
-			pr_err("failed to enable clock for clocksource: %d\n", ret);
+			pr_err("failed to enable clock for clocksource: %pe\n", ERR_PTR(ret));
 			goto out_clk_put;
 		}
 
@@ -209,7 +209,7 @@ static int __init mps2_clocksource_init(struct device_node *np)
 	base = of_iomap(np, 0);
 	if (!base) {
 		ret = -EADDRNOTAVAIL;
-		pr_err("failed to map register for clocksource: %d\n", ret);
+		pr_err("failed to map register for clocksource: %pe\n", ERR_PTR(ret));
 		goto out_clk_disable;
 	}
 
@@ -226,7 +226,7 @@ static int __init mps2_clocksource_init(struct device_node *np)
 				    rate, 200, 32,
 				    clocksource_mmio_readl_down);
 	if (ret) {
-		pr_err("failed to init clocksource: %d\n", ret);
+		pr_err("failed to init clocksource: %pe\n", ERR_PTR(ret));
 		goto out_iounmap;
 	}
 

--- a/drivers/clocksource/timer-clint.c
+++ b/drivers/clocksource/timer-clint.c
@@ -229,7 +229,7 @@ static int __init clint_timer_init_dt(struct device_node *np)
 
 	rc = clocksource_register_hz(&clint_clocksource, clint_timer_freq);
 	if (rc) {
-		pr_err("%pOFP: clocksource register failed [%d]\n", np, rc);
+		pr_err("%pOFP: clocksource register failed: %pe\n", np, ERR_PTR(rc));
 		goto fail_iounmap;
 	}
 
@@ -238,7 +238,7 @@ static int __init clint_timer_init_dt(struct device_node *np)
 	rc = request_percpu_irq(clint_timer_irq, clint_timer_interrupt,
 				 "clint-timer", &clint_clock_event);
 	if (rc) {
-		pr_err("registering percpu irq failed [%d]\n", rc);
+		pr_err("registering percpu irq failed: %pe\n", ERR_PTR(rc));
 		goto fail_iounmap;
 	}
 
@@ -260,7 +260,7 @@ static int __init clint_timer_init_dt(struct device_node *np)
 				clint_timer_starting_cpu,
 				clint_timer_dying_cpu);
 	if (rc) {
-		pr_err("%pOFP: cpuhp setup state failed [%d]\n", np, rc);
+		pr_err("%pOFP: cpuhp setup state failed: %pe\n", np, ERR_PTR(rc));
 		goto fail_free_irq;
 	}
 

--- a/drivers/clocksource/timer-digicolor.c
+++ b/drivers/clocksource/timer-digicolor.c
@@ -189,7 +189,7 @@ static int __init digicolor_timer_init(struct device_node *node)
 			  IRQF_TIMER | IRQF_IRQPOLL, "digicolor_timerC",
 			  &dc_timer_dev.ce);
 	if (ret) {
-		pr_warn("request of timer irq %d failed (%d)\n", irq, ret);
+		pr_warn("request of timer irq %d failed: %pe\n", irq, ERR_PTR(ret));
 		return ret;
 	}
 

--- a/drivers/clocksource/timer-fsl-ftm.c
+++ b/drivers/clocksource/timer-fsl-ftm.c
@@ -188,7 +188,7 @@ static int __init ftm_clockevent_init(unsigned long freq, int irq)
 	err = request_irq(irq, ftm_evt_interrupt, IRQF_TIMER | IRQF_IRQPOLL,
 			  "Freescale ftm timer", &ftm_clockevent);
 	if (err) {
-		pr_err("ftm: setup irq failed: %d\n", err);
+		pr_err("ftm: setup irq failed: %pe\n", ERR_PTR(err));
 		return err;
 	}
 
@@ -218,7 +218,7 @@ static int __init ftm_clocksource_init(unsigned long freq)
 				    freq / (1 << priv->ps), 300, 16,
 				    clocksource_mmio_readl_up);
 	if (err) {
-		pr_err("ftm: init clock source mmio failed: %d\n", err);
+		pr_err("ftm: init clock source mmio failed: %pe\n", ERR_PTR(err));
 		return err;
 	}
 
@@ -235,25 +235,25 @@ static int __init __ftm_clk_init(struct device_node *np, char *cnt_name,
 
 	clk = of_clk_get_by_name(np, cnt_name);
 	if (IS_ERR(clk)) {
-		pr_err("ftm: Cannot get \"%s\": %ld\n", cnt_name, PTR_ERR(clk));
+		pr_err("ftm: Cannot get \"%s\": %pe\n", cnt_name, clk);
 		return PTR_ERR(clk);
 	}
 	err = clk_prepare_enable(clk);
 	if (err) {
-		pr_err("ftm: clock failed to prepare+enable \"%s\": %d\n",
-			cnt_name, err);
+		pr_err("ftm: clock failed to prepare+enable \"%s\": %pe\n",
+			cnt_name, ERR_PTR(err));
 		return err;
 	}
 
 	clk = of_clk_get_by_name(np, ftm_name);
 	if (IS_ERR(clk)) {
-		pr_err("ftm: Cannot get \"%s\": %ld\n", ftm_name, PTR_ERR(clk));
+		pr_err("ftm: Cannot get \"%s\": %pe\n", ftm_name, clk);
 		return PTR_ERR(clk);
 	}
 	err = clk_prepare_enable(clk);
 	if (err)
-		pr_err("ftm: clock failed to prepare+enable \"%s\": %d\n",
-			ftm_name, err);
+		pr_err("ftm: clock failed to prepare+enable \"%s\": %pe\n",
+			ftm_name, ERR_PTR(err));
 
 	return clk_get_rate(clk);
 }

--- a/drivers/clocksource/timer-gxp.c
+++ b/drivers/clocksource/timer-gxp.c
@@ -86,13 +86,13 @@ static int __init gxp_timer_init(struct device_node *node)
 	clk = of_clk_get(node, 0);
 	if (IS_ERR(clk)) {
 		ret = (int)PTR_ERR(clk);
-		pr_err("%pOFn clock not found: %d\n", node, ret);
+		pr_err("%pOFn clock not found: %pe\n", node, clk);
 		goto err_free;
 	}
 
 	ret = clk_prepare_enable(clk);
 	if (ret) {
-		pr_err("%pOFn clock enable failed: %d\n", node, ret);
+		pr_err("%pOFn clock enable failed: %pe\n", node, ERR_PTR(ret));
 		goto err_clk_enable;
 	}
 
@@ -126,7 +126,7 @@ static int __init gxp_timer_init(struct device_node *node)
 	ret = clocksource_mmio_init(system_clock, node->name, freq,
 				    300, 32, clocksource_mmio_readl_up);
 	if (ret) {
-		pr_err("%pOFn init clocksource failed: %d", node, ret);
+		pr_err("%pOFn init clocksource failed: %pe", node, ERR_PTR(ret));
 		goto err_exit;
 	}
 
@@ -145,7 +145,7 @@ static int __init gxp_timer_init(struct device_node *node)
 	ret = request_irq(irq, gxp_timer_interrupt, IRQF_TIMER | IRQF_SHARED,
 			  node->name, gxp_timer);
 	if (ret) {
-		pr_err("%pOFn request_irq() failed: %d", node, ret);
+		pr_err("%pOFn request_irq() failed: %pe", node, ERR_PTR(ret));
 		goto err_exit;
 	}
 

--- a/drivers/clocksource/timer-imx-tpm.c
+++ b/drivers/clocksource/timer-imx-tpm.c
@@ -185,7 +185,7 @@ static int __init tpm_timer_init(struct device_node *np)
 	/* enable clk before accessing registers */
 	ret = clk_prepare_enable(ipg);
 	if (ret) {
-		pr_err("tpm: ipg clock enable failed (%d)\n", ret);
+		pr_err("tpm: ipg clock enable failed: %pe\n", ERR_PTR(ret));
 		clk_put(ipg);
 		return ret;
 	}

--- a/drivers/clocksource/timer-lpc32xx.c
+++ b/drivers/clocksource/timer-lpc32xx.c
@@ -161,13 +161,13 @@ static int __init lpc32xx_clocksource_init(struct device_node *np)
 
 	clk = of_clk_get_by_name(np, "timerclk");
 	if (IS_ERR(clk)) {
-		pr_err("clock get failed (%ld)\n", PTR_ERR(clk));
+		pr_err("clock get failed: %pe\n", clk);
 		return PTR_ERR(clk);
 	}
 
 	ret = clk_prepare_enable(clk);
 	if (ret) {
-		pr_err("clock enable failed (%d)\n", ret);
+		pr_err("clock enable failed: %pe\n", ERR_PTR(ret));
 		goto err_clk_enable;
 	}
 
@@ -193,7 +193,7 @@ static int __init lpc32xx_clocksource_init(struct device_node *np)
 	ret = clocksource_mmio_init(base + LPC32XX_TIMER_TC, "lpc3220 timer",
 				    rate, 300, 32, clocksource_mmio_readl_up);
 	if (ret) {
-		pr_err("failed to init clocksource (%d)\n", ret);
+		pr_err("failed to init clocksource: %pe\n", ERR_PTR(ret));
 		goto err_clocksource_init;
 	}
 
@@ -222,13 +222,13 @@ static int __init lpc32xx_clockevent_init(struct device_node *np)
 
 	clk = of_clk_get_by_name(np, "timerclk");
 	if (IS_ERR(clk)) {
-		pr_err("clock get failed (%ld)\n", PTR_ERR(clk));
+		pr_err("clock get failed: %pe\n", clk);
 		return PTR_ERR(clk);
 	}
 
 	ret = clk_prepare_enable(clk);
 	if (ret) {
-		pr_err("clock enable failed (%d)\n", ret);
+		pr_err("clock enable failed: %pe\n", ERR_PTR(ret));
 		goto err_clk_enable;
 	}
 

--- a/drivers/clocksource/timer-owl.c
+++ b/drivers/clocksource/timer-owl.c
@@ -137,7 +137,7 @@ static int __init owl_timer_init(struct device_node *node)
 	clk = of_clk_get(node, 0);
 	if (IS_ERR(clk)) {
 		ret = PTR_ERR(clk);
-		pr_err("Failed to get clock for clocksource (%d)\n", ret);
+		pr_err("Failed to get clock for clocksource: %pe\n", clk);
 		return ret;
 	}
 
@@ -150,7 +150,7 @@ static int __init owl_timer_init(struct device_node *node)
 	ret = clocksource_mmio_init(owl_clksrc_base + OWL_Tx_VAL, node->name,
 				    rate, 200, 32, clocksource_mmio_readl_up);
 	if (ret) {
-		pr_err("Failed to register clocksource (%d)\n", ret);
+		pr_err("Failed to register clocksource: %pe\n", ERR_PTR(ret));
 		return ret;
 	}
 

--- a/drivers/clocksource/timer-pistachio.c
+++ b/drivers/clocksource/timer-pistachio.c
@@ -174,25 +174,25 @@ static int __init pistachio_clksrc_of_init(struct device_node *node)
 
 	sys_clk = of_clk_get_by_name(node, "sys");
 	if (IS_ERR(sys_clk)) {
-		pr_err("clock get failed (%ld)\n", PTR_ERR(sys_clk));
+		pr_err("clock get failed: %pe\n", sys_clk);
 		return PTR_ERR(sys_clk);
 	}
 
 	fast_clk = of_clk_get_by_name(node, "fast");
 	if (IS_ERR(fast_clk)) {
-		pr_err("clock get failed (%lu)\n", PTR_ERR(fast_clk));
+		pr_err("clock get failed: %pe\n", fast_clk);
 		return PTR_ERR(fast_clk);
 	}
 
 	ret = clk_prepare_enable(sys_clk);
 	if (ret < 0) {
-		pr_err("failed to enable clock (%d)\n", ret);
+		pr_err("failed to enable clock: %pe\n", ERR_PTR(ret));
 		return ret;
 	}
 
 	ret = clk_prepare_enable(fast_clk);
 	if (ret < 0) {
-		pr_err("failed to enable clock (%d)\n", ret);
+		pr_err("failed to enable clock: %pe\n", ERR_PTR(ret));
 		clk_disable_unprepare(sys_clk);
 		return ret;
 	}

--- a/drivers/clocksource/timer-probe.c
+++ b/drivers/clocksource/timer-probe.c
@@ -30,8 +30,8 @@ void __init timer_probe(void)
 		ret = init_func_ret(np);
 		if (ret) {
 			if (ret != -EPROBE_DEFER)
-				pr_err("Failed to initialize '%pOF': %d\n", np,
-				       ret);
+				pr_err("Failed to initialize '%pOF': %pe\n", np,
+				       ERR_PTR(ret));
 			continue;
 		}
 

--- a/drivers/clocksource/timer-riscv.c
+++ b/drivers/clocksource/timer-riscv.c
@@ -169,7 +169,7 @@ static int __init riscv_timer_init_common(void)
 
 	error = clocksource_register_hz(&riscv_clocksource, riscv_timebase);
 	if (error) {
-		pr_err("RISCV timer registration failed [%d]\n", error);
+		pr_err("RISCV timer registration failed: %pe\n", ERR_PTR(error));
 		return error;
 	}
 
@@ -179,7 +179,7 @@ static int __init riscv_timer_init_common(void)
 				    riscv_timer_interrupt,
 				    "riscv-timer", &riscv_clock_event);
 	if (error) {
-		pr_err("registering percpu irq failed [%d]\n", error);
+		pr_err("registering percpu irq failed: %pe\n", ERR_PTR(error));
 		return error;
 	}
 
@@ -192,8 +192,8 @@ static int __init riscv_timer_init_common(void)
 			 "clockevents/riscv/timer:starting",
 			 riscv_timer_starting_cpu, riscv_timer_dying_cpu);
 	if (error)
-		pr_err("cpu hp setup state failed for RISCV timer [%d]\n",
-		       error);
+		pr_err("cpu hp setup state failed for RISCV timer: %pe\n",
+		       ERR_PTR(error));
 
 	return error;
 }

--- a/drivers/clocksource/timer-sp804.c
+++ b/drivers/clocksource/timer-sp804.c
@@ -66,13 +66,13 @@ static long __init sp804_get_clock_rate(struct clk *clk, const char *name)
 	if (!clk)
 		clk = clk_get_sys("sp804", name);
 	if (IS_ERR(clk)) {
-		pr_err("%s clock not found: %ld\n", name, PTR_ERR(clk));
+		pr_err("%s clock not found: %pe\n", name, clk);
 		return PTR_ERR(clk);
 	}
 
 	err = clk_prepare_enable(clk);
 	if (err) {
-		pr_err("clock failed to enable: %d\n", err);
+		pr_err("clock failed to enable: %pe\n", ERR_PTR(err));
 		clk_put(clk);
 		return err;
 	}

--- a/drivers/clocksource/timer-tegra.c
+++ b/drivers/clocksource/timer-tegra.c
@@ -324,8 +324,8 @@ static int __init tegra_init_timer(struct device_node *np, bool tegra20,
 		ret = request_irq(cpu_to->clkevt.irq, tegra_timer_isr, flags,
 				  cpu_to->clkevt.name, &cpu_to->clkevt);
 		if (ret) {
-			pr_err("failed to set up irq for cpu%d: %d\n",
-			       cpu, ret);
+			pr_err("failed to set up irq for cpu%d: %pe\n",
+			       cpu, ERR_PTR(ret));
 			irq_dispose_mapping(cpu_to->clkevt.irq);
 			cpu_to->clkevt.irq = 0;
 			goto out_irq;
@@ -338,7 +338,7 @@ static int __init tegra_init_timer(struct device_node *np, bool tegra20,
 				    "timer_us", TIMER_1MHz, 300, 32,
 				    clocksource_mmio_readl_up);
 	if (ret)
-		pr_err("failed to register clocksource: %d\n", ret);
+		pr_err("failed to register clocksource: %pe\n", ERR_PTR(ret));
 
 #ifdef CONFIG_ARM
 	register_current_timer_delay(&tegra_delay_timer);
@@ -348,7 +348,7 @@ static int __init tegra_init_timer(struct device_node *np, bool tegra20,
 				"AP_TEGRA_TIMER_STARTING", tegra_timer_setup,
 				tegra_timer_stop);
 	if (ret)
-		pr_err("failed to set up cpu hp state: %d\n", ret);
+		pr_err("failed to set up cpu hp state: %pe\n", ERR_PTR(ret));
 
 	return ret;
 

--- a/drivers/clocksource/timer-tegra186.c
+++ b/drivers/clocksource/timer-tegra186.c
@@ -279,13 +279,13 @@ static struct tegra186_wdt *tegra186_wdt_create(struct tegra186_timer *tegra,
 
 	err = watchdog_init_timeout(&wdt->base, 5, tegra->dev);
 	if (err < 0) {
-		dev_err(tegra->dev, "failed to initialize timeout: %d\n", err);
+		dev_err(tegra->dev, "failed to initialize timeout: %pe\n", ERR_PTR(err));
 		return ERR_PTR(err);
 	}
 
 	err = devm_watchdog_register_device(tegra->dev, &wdt->base);
 	if (err < 0) {
-		dev_err(tegra->dev, "failed to register WDT: %d\n", err);
+		dev_err(tegra->dev, "failed to register WDT: %pe\n", ERR_PTR(err));
 		return ERR_PTR(err);
 	}
 
@@ -406,32 +406,32 @@ static int tegra186_timer_probe(struct platform_device *pdev)
 	tegra->wdt = tegra186_wdt_create(tegra, 0);
 	if (IS_ERR(tegra->wdt)) {
 		err = PTR_ERR(tegra->wdt);
-		dev_err(dev, "failed to create WDT: %d\n", err);
+		dev_err(dev, "failed to create WDT: %pe\n", tegra->wdt);
 		return err;
 	}
 
 	err = tegra186_timer_tsc_init(tegra);
 	if (err < 0) {
-		dev_err(dev, "failed to register TSC counter: %d\n", err);
+		dev_err(dev, "failed to register TSC counter: %pe\n", ERR_PTR(err));
 		return err;
 	}
 
 	err = tegra186_timer_osc_init(tegra);
 	if (err < 0) {
-		dev_err(dev, "failed to register OSC counter: %d\n", err);
+		dev_err(dev, "failed to register OSC counter: %pe\n", ERR_PTR(err));
 		goto unregister_tsc;
 	}
 
 	err = tegra186_timer_usec_init(tegra);
 	if (err < 0) {
-		dev_err(dev, "failed to register USEC counter: %d\n", err);
+		dev_err(dev, "failed to register USEC counter: %pe\n", ERR_PTR(err));
 		goto unregister_osc;
 	}
 
 	err = devm_request_irq(dev, irq, tegra186_timer_irq, 0,
 			       "tegra186-timer", tegra);
 	if (err < 0) {
-		dev_err(dev, "failed to request IRQ#%u: %d\n", irq, err);
+		dev_err(dev, "failed to request IRQ#%u: %pe\n", irq, ERR_PTR(err));
 		goto unregister_usec;
 	}
 

--- a/drivers/clocksource/timer-zevio.c
+++ b/drivers/clocksource/timer-zevio.c
@@ -134,7 +134,7 @@ static int __init zevio_timer_add(struct device_node *node)
 	timer->clk = of_clk_get(node, 0);
 	if (IS_ERR(timer->clk)) {
 		ret = PTR_ERR(timer->clk);
-		pr_err("Timer clock not found! (error %d)\n", ret);
+		pr_err("Timer clock not found! error: %pe\n", timer->clk);
 		goto error_unmap;
 	}
 


### PR DESCRIPTION
Pull request for series with
subject: clocksource: use symbolic error names (%pe) to print logs
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=855999
