### PR TITLE
bpf: resolve_btfids: Fix integer overflow when calling elf_update()

### DIFF
--- a/tools/bpf/resolve_btfids/main.c
+++ b/tools/bpf/resolve_btfids/main.c
@@ -728,7 +728,7 @@ static int sets_patch(struct object *obj)
 
 static int symbols_patch(struct object *obj)
 {
-	int err;
+	off_t err;
 
 	if (__symbols_patch(obj, &obj->structs)  ||
 	    __symbols_patch(obj, &obj->unions)   ||


### PR DESCRIPTION
Pull request for series with
subject: bpf: resolve_btfids: Fix integer overflow when calling elf_update()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=856225
