### PR TITLE
clk: sifive: prci: fix module autoloading

### DIFF
--- a/drivers/clk/sifive/sifive-prci.c
+++ b/drivers/clk/sifive/sifive-prci.c
@@ -611,6 +611,7 @@ static const struct of_device_id sifive_prci_of_match[] = {
 	{.compatible = "sifive,fu740-c000-prci", .data = &prci_clk_fu740},
 	{}
 };
+MODULE_DEVICE_TABLE(of, sifive_prci_of_match);
 
 static struct platform_driver sifive_prci_driver = {
 	.driver = {


### PR DESCRIPTION
Pull request for series with
subject: clk: sifive: prci: fix module autoloading
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=858667
