### PR TITLE
riscv: vdso: do not strip debugging info for vdso.so.dbg

### DIFF
--- a/arch/riscv/kernel/vdso/Makefile
+++ b/arch/riscv/kernel/vdso/Makefile
@@ -45,7 +45,7 @@ $(obj)/vdso.o: $(obj)/vdso.so
 # link rule for the .so file, .lds has to be first
 $(obj)/vdso.so.dbg: $(obj)/vdso.lds $(obj-vdso) FORCE
 	$(call if_changed,vdsold)
-LDFLAGS_vdso.so.dbg = -shared -S -soname=linux-vdso.so.1 \
+LDFLAGS_vdso.so.dbg = -shared -soname=linux-vdso.so.1 \
 	--build-id=sha1 --hash-style=both --eh-frame-hdr
 
 # strip rule for the .so file


### PR DESCRIPTION
Pull request for series with
subject: riscv: vdso: do not strip debugging info for vdso.so.dbg
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=860627
