### PR TITLE
riscv: dts: starfive: Set EMMC vqmmc maximum voltage to 3.3V on JH7110 boards

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
@@ -244,7 +244,7 @@
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
+				regulator-max-microvolt = <3300000>;
 				regulator-name = "emmc_vdd";
 			};
 		};


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: starfive: Set EMMC vqmmc maximum voltage to 3.3V on JH7110 boards
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=860834
