### PR TITLE
RISC-V: Dynamically allocate cpumasks and further increase range and default value of NR_CPUS

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -84,6 +84,7 @@ config RISCV
 	select CLINT_TIMER if RISCV_M_MODE
 	select CLONE_BACKWARDS
 	select COMMON_CLK
+	select CPUMASK_OFFSTACK if NR_CPUS > 512
 	select CPU_PM if CPU_IDLE || HIBERNATION || SUSPEND
 	select EDAC_SUPPORT
 	select FRAME_POINTER if PERF_EVENTS || (FUNCTION_TRACER && !DYNAMIC_FTRACE)
@@ -435,11 +436,11 @@ config SCHED_MC
 config NR_CPUS
 	int "Maximum number of CPUs (2-512)"
 	depends on SMP
-	range 2 512 if !RISCV_SBI_V01
+	range 2 4096 if !RISCV_SBI_V01
 	range 2 32 if RISCV_SBI_V01 && 32BIT
 	range 2 64 if RISCV_SBI_V01 && 64BIT
 	default "32" if 32BIT
-	default "64" if 64BIT
+	default "512" if 64BIT
 
 config HOTPLUG_CPU
 	bool "Support for hot-pluggable CPUs"


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: Dynamically allocate cpumasks and further increase range and default value of NR_CPUS
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=861960
