### PR TITLE
riscv: dts: sophgo: disable write-protection for milkv duo

### DIFF
--- a/arch/riscv/boot/dts/sophgo/cv1800b-milkv-duo.dts
+++ b/arch/riscv/boot/dts/sophgo/cv1800b-milkv-duo.dts
@@ -45,6 +45,7 @@
 	no-1-8-v;
 	no-mmc;
 	no-sdio;
+	disable-wp;
 };
 
 &uart0 {


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: sophgo: disable write-protection for milkv duo
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=862945
