### PR TITLE
riscv: Fix local irq restore when flags indicates irq disabled

### DIFF
--- a/arch/riscv/include/asm/irqflags.h
+++ b/arch/riscv/include/asm/irqflags.h
@@ -48,7 +48,10 @@ static inline int arch_irqs_disabled(void)
 /* set interrupt enabled status */
 static inline void arch_local_irq_restore(unsigned long flags)
 {
-	csr_set(CSR_STATUS, flags & SR_IE);
+	if (flags & SR_IE)
+		csr_set(CSR_STATUS, SR_IE);
+	else
+		csr_clear(CSR_STATUS, SR_IE);
 }
 
 #endif /* _ASM_RISCV_IRQFLAGS_H */


### PR DESCRIPTION
Pull request for series with
subject: riscv: Fix local irq restore when flags indicates irq disabled
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=862972
