### PR TITLE
riscv: Randomize lower bits of stack address

### DIFF
--- a/arch/riscv/include/asm/exec.h
+++ b/arch/riscv/include/asm/exec.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __ASM_EXEC_H
+#define __ASM_EXEC_H
+
+extern unsigned long arch_align_stack(unsigned long sp);
+
+#endif	/* __ASM_EXEC_H */

--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -15,6 +15,7 @@
 #include <linux/tick.h>
 #include <linux/ptrace.h>
 #include <linux/uaccess.h>
+#include <linux/personality.h>
 
 #include <asm/unistd.h>
 #include <asm/processor.h>
@@ -26,6 +27,7 @@
 #include <asm/cpuidle.h>
 #include <asm/vector.h>
 #include <asm/cpufeature.h>
+#include <asm/exec.h>
 
 #if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)
 #include <linux/stackprotector.h>
@@ -97,6 +99,13 @@ void show_regs(struct pt_regs *regs)
 	__show_regs(regs);
 	if (!user_mode(regs))
 		dump_backtrace(regs, NULL, KERN_DEFAULT);
+}
+
+unsigned long arch_align_stack(unsigned long sp)
+{
+	if (!(current->personality & ADDR_NO_RANDOMIZE) && randomize_va_space)
+		sp -= get_random_u32_below(PAGE_SIZE);
+	return sp & ~0xf;
 }
 
 #ifdef CONFIG_COMPAT


### PR DESCRIPTION
Pull request for series with
subject: riscv: Randomize lower bits of stack address
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=865146
