### PR TITLE
riscv: selftests: Fix vsetivli args for clang

### DIFF
--- a/tools/testing/selftests/riscv/sigreturn/sigreturn.c
+++ b/tools/testing/selftests/riscv/sigreturn/sigreturn.c
@@ -51,7 +51,7 @@ static int vector_sigreturn(int data, void (*handler)(int, siginfo_t *, void *))
 
 	asm(".option push				\n\
 		.option		arch, +v		\n\
-		vsetivli	x0, 1, e32, ta, ma	\n\
+		vsetivli	x0, 1, e32, m1, ta, ma	\n\
 		vmv.s.x		v0, %1			\n\
 		# Generate SIGSEGV			\n\
 		lw		a0, 0(x0)		\n\


### PR DESCRIPTION
Pull request for series with
subject: riscv: selftests: Fix vsetivli args for clang
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=867787
