### PR TITLE
riscv: define ILLEGAL_POINTER_VALUE for 64bit

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -319,6 +319,11 @@ config GENERIC_HWEIGHT
 config FIX_EARLYCON_MEM
 	def_bool MMU
 
+config ILLEGAL_POINTER_VALUE
+	hex
+	default 0 if 32BIT
+	default 0xdead000000000000 if 64BIT
+
 config PGTABLE_LEVELS
 	int
 	default 5 if 64BIT


### PR DESCRIPTION
Pull request for series with
subject: riscv: define ILLEGAL_POINTER_VALUE for 64bit
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=868890
