### PR TITLE
serial: 8250: don't lost port's default capabilities

### DIFF
--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -3245,8 +3245,7 @@ void serial8250_set_defaults(struct uart_8250_port *up)
 			up->port.fifosize = uart_config[type].fifo_size;
 		if (!up->tx_loadsz)
 			up->tx_loadsz = uart_config[type].tx_loadsz;
-		if (!up->capabilities)
-			up->capabilities = uart_config[type].flags;
+		up->capabilities |= uart_config[type].flags;
 	}
 
 	set_io_from_upio(port);


### PR DESCRIPTION
Pull request for series with
subject: serial: 8250: don't lost port's default capabilities
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=868973
