### PR TITLE
riscv: dts: starfive: remove non-existant spi device from jh7110-common.dtsi

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
@@ -357,12 +357,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;
 	status = "okay";
-
-	spi_dev0: spi@0 {
-		compatible = "rohm,dh2228fv";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &sysgpio {


### PR DESCRIPTION
Pull request for series with
subject: riscv: dts: starfive: remove non-existant spi device from jh7110-common.dtsi
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=871654
