### PR TITLE
riscv: Allow to build only with LLVM >= 17.0.0

### DIFF
--- a/scripts/min-tool-version.sh
+++ b/scripts/min-tool-version.sh
@@ -28,6 +28,8 @@ llvm)
 		echo 15.0.0
 	elif [ "$SRCARCH" = loongarch ]; then
 		echo 18.0.0
+	elif [ "$SRCARCH" = riscv ]; then
+		echo 17.0.0
 	else
 		echo 13.0.1
 	fi


### PR DESCRIPTION
Pull request for series with
subject: riscv: Allow to build only with LLVM >= 17.0.0
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=871960
