### PR TITLE
RISC-V: Enable IPI CPU Backtrace

### DIFF
--- a/arch/riscv/include/asm/irq.h
+++ b/arch/riscv/include/asm/irq.h
@@ -12,6 +12,11 @@
 
 #include <asm-generic/irq.h>
 
+#ifdef CONFIG_SMP
+void arch_trigger_cpumask_backtrace(const cpumask_t *mask, int exclude_cpu);
+#define arch_trigger_cpumask_backtrace arch_trigger_cpumask_backtrace
+#endif
+
 void riscv_set_intc_hwnode_fn(struct fwnode_handle *(*fn)(void));
 
 struct fwnode_handle *riscv_get_intc_hwnode(void);


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: Enable IPI CPU Backtrace
version: 2
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=872209
