### PR TITLE
crash: Fix crash memory reserve exceed system memory bug

### DIFF
--- a/kernel/crash_reserve.c
+++ b/kernel/crash_reserve.c
@@ -335,6 +335,9 @@ int __init parse_crashkernel(char *cmdline,
 	if (!*crash_size)
 		ret = -EINVAL;
 
+	if (*crash_size >= system_ram)
+		ret = -EINVAL;
+
 	return ret;
 }
 


### PR DESCRIPTION
Pull request for series with
subject: crash: Fix crash memory reserve exceed system memory bug
version: 5
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=873104
