### PR TITLE
MAINTAINERS: invert Misc RISC-V SoC Support's pattern

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -19653,12 +19653,10 @@ L:	linux-riscv@lists.infradead.org
 S:	Maintained
 Q:	https://patchwork.kernel.org/project/linux-riscv/list/
 T:	git https://git.kernel.org/pub/scm/linux/kernel/git/conor/linux.git/
-F:	Documentation/devicetree/bindings/riscv/
-F:	arch/riscv/boot/dts/
-X:	arch/riscv/boot/dts/allwinner/
-X:	arch/riscv/boot/dts/renesas/
-X:	arch/riscv/boot/dts/sophgo/
-X:	arch/riscv/boot/dts/thead/
+F:	arch/riscv/boot/dts/canaan/
+F:	arch/riscv/boot/dts/microchip/
+F:	arch/riscv/boot/dts/sifive/
+F:	arch/riscv/boot/dts/starfive/
 
 RISC-V PMU DRIVERS
 M:	Atish Patra <atishp@atishpatra.org>


### PR DESCRIPTION
Pull request for series with
subject: MAINTAINERS: invert Misc RISC-V SoC Support's pattern
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=877174
