### PR TITLE
riscv: Remove unused GENERATING_ASM_OFFSETS

### DIFF
--- a/arch/riscv/kernel/asm-offsets.c
+++ b/arch/riscv/kernel/asm-offsets.c
@@ -4,8 +4,6 @@
  * Copyright (C) 2017 SiFive
  */
 
-#define GENERATING_ASM_OFFSETS
-
 #include <linux/kbuild.h>
 #include <linux/mm.h>
 #include <linux/sched.h>


### PR DESCRIPTION
Pull request for series with
subject: riscv: Remove unused GENERATING_ASM_OFFSETS
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=880290
