### PR TITLE
irqchip/riscv-aplic: Fix an IS_ERR() vs NULL bug in probe()

### DIFF
--- a/drivers/irqchip/irq-riscv-aplic-main.c
+++ b/drivers/irqchip/irq-riscv-aplic-main.c
@@ -175,9 +175,9 @@ static int aplic_probe(struct platform_device *pdev)
 
 	/* Map the MMIO registers */
 	regs = devm_platform_ioremap_resource(pdev, 0);
-	if (!regs) {
+	if (IS_ERR(regs)) {
 		dev_err(dev, "failed map MMIO registers\n");
-		return -ENOMEM;
+		return PTR_ERR(regs);
 	}
 
 	/*


### PR DESCRIPTION
Pull request for series with
subject: irqchip/riscv-aplic: Fix an IS_ERR() vs NULL bug in probe()
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=881227
