### PR TITLE
RISC-V: KVM: Redirect instruction access fault trap to guest

### DIFF
--- a/arch/riscv/kvm/vcpu_exit.c
+++ b/arch/riscv/kvm/vcpu_exit.c
@@ -182,6 +182,7 @@ int kvm_riscv_vcpu_exit(struct kvm_vcpu *vcpu, struct kvm_run *run,
 	ret = -EFAULT;
 	run->exit_reason = KVM_EXIT_UNKNOWN;
 	switch (trap->scause) {
+	case EXC_INST_ACCESS:
 	case EXC_INST_ILLEGAL:
 	case EXC_LOAD_MISALIGNED:
 	case EXC_STORE_MISALIGNED:


### PR DESCRIPTION
Pull request for series with
subject: RISC-V: KVM: Redirect instruction access fault trap to guest
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=884579
