### PR TITLE
riscv: Use '%u' to format the output of 'cpu'

### DIFF
--- a/arch/riscv/kernel/cpu-hotplug.c
+++ b/arch/riscv/kernel/cpu-hotplug.c
@@ -58,7 +58,7 @@ void arch_cpuhp_cleanup_dead_cpu(unsigned int cpu)
 	if (cpu_ops->cpu_is_stopped)
 		ret = cpu_ops->cpu_is_stopped(cpu);
 	if (ret)
-		pr_warn("CPU%d may not have stopped: %d\n", cpu, ret);
+		pr_warn("CPU%u may not have stopped: %d\n", cpu, ret);
 }
 
 /*


### PR DESCRIPTION
Pull request for series with
subject: riscv: Use '%u' to format the output of 'cpu'
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=887799
