### PR TITLE
mmc: core: Only set maximum DMA segment size if DMA is supported

### DIFF
--- a/drivers/mmc/core/queue.c
+++ b/drivers/mmc/core/queue.c
@@ -388,7 +388,8 @@ static struct gendisk *mmc_alloc_disk(struct mmc_queue *mq,
 
 	blk_queue_rq_timeout(mq->queue, 60 * HZ);
 
-	dma_set_max_seg_size(mmc_dev(host), queue_max_segment_size(mq->queue));
+	if (mmc_dev(host)->dma_parms)
+		dma_set_max_seg_size(mmc_dev(host), queue_max_segment_size(mq->queue));
 
 	INIT_WORK(&mq->recovery_work, mmc_mq_recovery_handler);
 	INIT_WORK(&mq->complete_work, mmc_blk_mq_complete_work);


### PR DESCRIPTION
Pull request for series with
subject: mmc: core: Only set maximum DMA segment size if DMA is supported
version: 1
url: https://patchwork.kernel.org/project/linux-riscv/list/?series=892563
